### PR TITLE
fix #23: detect a pre-exisitng facebook container

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,65 +1,98 @@
-let facebookCookieStoreId = null;
-
 // Param values from https://developer.mozilla.org/Add-ons/WebExtensions/API/contextualIdentities/create
 const FACEBOOK_CONTAINER_NAME = "Facebook";
 const FACEBOOK_CONTAINER_COLOR = "blue";
 const FACEBOOK_CONTAINER_ICON = "briefcase";
-const FACEBOOK_DOMAINS = ["facebook.com", "fb.com"];
+const FACEBOOK_DOMAINS = ["facebook.com", "www.facebook.com", "fb.com"];
+
+let facebookCookieStoreId = null;
 
 const facebookHostREs = [];
 
-for (let facebookDomain of FACEBOOK_DOMAINS) {
-  facebookHostREs.push(new RegExp(`^(.*)?${facebookDomain}$`));
-  const facebookCookieUrl = `https://${facebookDomain}/`;
-
-  browser.cookies.getAll({domain: facebookDomain}).then(cookies => {
-    for (let cookie of cookies) {
-      browser.cookies.remove({name: cookie.name, url: facebookCookieUrl});
+async function isFacebookAlreadyAssignedInMAC () {
+  let anyFBDomainsAssigned = false;
+  for (let facebookDomain of FACEBOOK_DOMAINS) {
+    const facebookCookieUrl = `https://${facebookDomain}/`;
+    let assignment;
+    try {
+      assignment = await browser.runtime.sendMessage("@testpilot-containers", {
+        method: "getAssignment",
+        url: facebookCookieUrl
+      });
+    } catch (e) {
+      return false;
     }
-  });
+    if (assignment) {
+      anyFBDomainsAssigned = true;
+    }
+  }
+  return anyFBDomainsAssigned;
 }
 
-browser.contextualIdentities.query({name: FACEBOOK_CONTAINER_NAME}).then(contexts => {
-  if (contexts.length > 0) {
-    facebookCookieStoreId = contexts[0].cookieStoreId;
-  } else {
-    browser.contextualIdentities.create({
-      name: FACEBOOK_CONTAINER_NAME,
-      color: FACEBOOK_CONTAINER_COLOR,
-      icon: FACEBOOK_CONTAINER_ICON}
-    ).then(context => {
-      facebookCookieStoreId = context.cookieStoreId;
+(async function init() {
+  const facebookAlreadyAssigned = await isFacebookAlreadyAssignedInMAC();
+  if (facebookAlreadyAssigned) {
+    return;
+  }
+
+  // Clear all facebook cookies
+  for (let facebookDomain of FACEBOOK_DOMAINS) {
+    facebookHostREs.push(new RegExp(`^(.*)?${facebookDomain}$`));
+    const facebookCookieUrl = `https://${facebookDomain}/`;
+
+    browser.cookies.getAll({domain: facebookDomain}).then(cookies => {
+      for (let cookie of cookies) {
+        browser.cookies.remove({name: cookie.name, url: facebookCookieUrl});
+      }
     });
   }
-});
 
-async function containFacebook(options) {
-  const requestUrl = new URL(options.url);
-  let isFacebook = false;
-  for (let facebookHostRE of facebookHostREs) {
-    if (facebookHostRE.test(requestUrl.host)) {
-      isFacebook = true;
-      break;
+  // Use existing Facebook container, or create one
+  browser.contextualIdentities.query({name: FACEBOOK_CONTAINER_NAME}).then(contexts => {
+    if (contexts.length > 0) {
+      facebookCookieStoreId = contexts[0].cookieStoreId;
+    } else {
+      browser.contextualIdentities.create({
+        name: FACEBOOK_CONTAINER_NAME,
+        color: FACEBOOK_CONTAINER_COLOR,
+        icon: FACEBOOK_CONTAINER_ICON}
+      ).then(context => {
+        facebookCookieStoreId = context.cookieStoreId;
+      });
     }
-  }
-  const tab = await browser.tabs.get(options.tabId);
-  const tabCookieStoreId = tab.cookieStoreId;
-  if (isFacebook) {
-    if (tabCookieStoreId !== facebookCookieStoreId && !tab.incognito) {
-      // See https://github.com/mozilla/contain-facebook/issues/23
-      // Sometimes this add-on is installed but doesn't get a facebookCookieStoreId ?
-      if (facebookCookieStoreId) {
-        browser.tabs.create({url: requestUrl.toString(), cookieStoreId: facebookCookieStoreId});
+  });
+
+  // Listen to requests and open Facebook into its Container,
+  // open other sites into the default tab context
+  async function containFacebook(options) {
+    const requestUrl = new URL(options.url);
+    let isFacebook = false;
+    for (let facebookHostRE of facebookHostREs) {
+      if (facebookHostRE.test(requestUrl.host)) {
+        isFacebook = true;
+        break;
+      }
+    }
+    const tab = await browser.tabs.get(options.tabId);
+    const tabCookieStoreId = tab.cookieStoreId;
+    if (isFacebook) {
+      if (tabCookieStoreId !== facebookCookieStoreId && !tab.incognito) {
+        // See https://github.com/mozilla/contain-facebook/issues/23
+        // Sometimes this add-on is installed but doesn't get a facebookCookieStoreId ?
+        if (facebookCookieStoreId) {
+          browser.tabs.create({url: requestUrl.toString(), cookieStoreId: facebookCookieStoreId});
+          browser.tabs.remove(options.tabId);
+          return {cancel: true};
+        }
+      }
+    } else {
+      if (tabCookieStoreId === facebookCookieStoreId) {
+        browser.tabs.create({url: requestUrl.toString()});
         browser.tabs.remove(options.tabId);
         return {cancel: true};
       }
     }
-  } else {
-    if (tabCookieStoreId === facebookCookieStoreId) {
-      browser.tabs.create({url: requestUrl.toString()});
-      browser.tabs.remove(options.tabId);
-      return {cancel: true};
-    }
   }
-}
-browser.webRequest.onBeforeRequest.addListener(containFacebook, {urls: ["<all_urls>"], types: ["main_frame"]}, ["blocking"]);
+
+  // Add the request listener
+  browser.webRequest.onBeforeRequest.addListener(containFacebook, {urls: ["<all_urls>"], types: ["main_frame"]}, ["blocking"]);
+})();


### PR DESCRIPTION
If a user installed multi-account-containers, they may already have
facebook.com assigned to a container. We detect and delete that
container, so it does not conflict with this container.

Note: I think we need to do some serious UX consideration on this. As @TanviHacks mentions , a user with facebook.com already assigned to a "Social" container will lose that entire container, and a user (like me) with facebook.com already assigned to a "Personal" container will lose that entire container.

We don't have any data on how many users fall into these use-cases, but based on how frustrated MAC users have been when updates accidentally delete their containers, we may end up frustrating MANY of our existing MAC users with this implementation.

An alternative implementation is to detect users who have already assigned facebook.com to a Container, and just leave those users alone. This seems like the safest and most non-destructive move. It could be combined with information on the AMO page describing how to use MAC for similar protection from Facebook.

Basically, I'm okay to merge and ship this implementation, but I'm also very worried about having to handle the fall-out and potential fast-follow bug-fixes from it.