### PR TITLE
Add messenger.com to Facebook URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,7 +2,7 @@
 const FACEBOOK_CONTAINER_NAME = "Facebook";
 const FACEBOOK_CONTAINER_COLOR = "blue";
 const FACEBOOK_CONTAINER_ICON = "briefcase";
-const FACEBOOK_DOMAINS = ["facebook.com", "www.facebook.com", "fb.com"];
+const FACEBOOK_DOMAINS = ["facebook.com", "www.facebook.com", "fb.com", "messenger.com", "www.messenger.com"];
 
 let facebookCookieStoreId = null;
 


### PR DESCRIPTION
Many Facebook users access Facebook messenger through [messenger.com](https://www.messenger.com). Cookies from Facebook.com and messenger.com should be contained together.