### PR TITLE
Make sure that only configured domains and their subdomains are contained

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,7 +36,7 @@ async function isFacebookAlreadyAssignedInMAC () {
 
   // Clear all facebook cookies
   for (let facebookDomain of FACEBOOK_DOMAINS) {
-    facebookHostREs.push(new RegExp(`^(.*)?${facebookDomain}$`));
+    facebookHostREs.push(new RegExp(`^(.*\\.)?${facebookDomain}$`));
     const facebookCookieUrl = `https://${facebookDomain}/`;
 
     browser.cookies.getAll({domain: facebookDomain}).then(cookies => {


### PR DESCRIPTION
Currently the regular expression matches all hostnames that end with hostnames defined in `FACEBOOK_DOMAINS`, which also includes hostnames like [deletefacebook.com](https://deletefacebook.com/). This PR makes sure that only subdomains are matched instead.

Fixes #49 