### PR TITLE
Block outgoing Facebook cookies in all Non-Facebook Containers

### DIFF
--- a/background.js
+++ b/background.js
@@ -11,9 +11,9 @@ const MAC_ADDON_ID = "@testpilot-containers";
 
 let macAddonEnabled = false;
 let facebookCookieStoreId = null;
-let facebookCookiesCleared = false;
 
 const canceledRequests = {};
+const tabsWaitingToLoad = {};
 const facebookHostREs = [];
 
 async function isMACAddonEnabled () {
@@ -38,20 +38,24 @@ async function setupMACAddonManagementListeners () {
     if (info.id === MAC_ADDON_ID) {
       macAddonEnabled = false;
     }
-  })
+  });
   browser.management.onEnabled.addListener(info => {
     if (info.id === MAC_ADDON_ID) {
       macAddonEnabled = true;
     }
-  })
+  });
   browser.management.onDisabled.addListener(info => {
     if (info.id === MAC_ADDON_ID) {
       macAddonEnabled = false;
     }
-  })
+  });
 }
 
 async function getMACAssignment (url) {
+  if (!macAddonEnabled) {
+    return false;
+  }
+
   try {
     const assignment = await browser.runtime.sendMessage(MAC_ADDON_ID, {
       method: "getAssignment",
@@ -116,7 +120,7 @@ async function clearFacebookCookies () {
   // Clear all facebook cookies
   const containers = await browser.contextualIdentities.query({});
   containers.push({
-    cookieStoreId: 'firefox-default'
+    cookieStoreId: "firefox-default"
   });
   containers.map(container => {
     const storeId = container.cookieStoreId;
@@ -146,7 +150,7 @@ async function clearFacebookCookies () {
 
 async function setupContainer () {
   // Use existing Facebook container, or create one
-  const contexts = await browser.contextualIdentities.query({name: FACEBOOK_CONTAINER_NAME})
+  const contexts = await browser.contextualIdentities.query({name: FACEBOOK_CONTAINER_NAME});
   if (contexts.length > 0) {
     facebookCookieStoreId = contexts[0].cookieStoreId;
   } else {
@@ -159,82 +163,176 @@ async function setupContainer () {
   }
 }
 
+function reopenTab ({url, tab, cookieStoreId}) {
+  browser.tabs.create({
+    url,
+    cookieStoreId,
+    active: tab.active,
+    index: tab.index,
+    windowId: tab.windowId
+  });
+  browser.tabs.remove(tab.id);
+}
+
+function isFacebookURL (url) {
+  const parsedUrl = new URL(url);
+  for (let facebookHostRE of facebookHostREs) {
+    if (facebookHostRE.test(parsedUrl.host)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldContainInto (url, tab) {
+  if (!url.startsWith("http")) {
+    // we only handle URLs starting with http(s)
+    return false;
+  }
+
+  if (isFacebookURL(url)) {
+    if (tab.cookieStoreId !== facebookCookieStoreId) {
+      // Facebook-URL outside of Facebook Container Tab
+      // Should contain into Facebook Container
+      return facebookCookieStoreId;
+    }
+  } else if (tab.cookieStoreId === facebookCookieStoreId) {
+    // Non-Facebook-URL inside Facebook Container Tab
+    // Should contain into Default Container
+    return "firefox-default";
+  }
+
+  return false;
+}
+
+async function maybeReopenAlreadyOpenTabs () {
+  const maybeReopenTab = async tab => {
+    const macAssigned = await getMACAssignment(tab.url);
+    if (macAssigned) {
+      // We don't reopen MAC assigned urls
+      return;
+    }
+    const cookieStoreId = shouldContainInto(tab.url, tab);
+    if (!cookieStoreId) {
+      // Tab doesn't need to be contained
+      return;
+    }
+    reopenTab({
+      url: tab.url,
+      tab,
+      cookieStoreId
+    });
+  };
+
+  const tabsOnUpdated = (tabId, changeInfo, tab) => {
+    if (changeInfo.url && tabsWaitingToLoad[tabId]) {
+      // Tab we're waiting for switched it's url, maybe we reopen
+      delete tabsWaitingToLoad[tabId];
+      maybeReopenTab(tab);
+    }
+    if (tab.status === "complete" && tabsWaitingToLoad[tabId]) {
+      // Tab we're waiting for completed loading
+      delete tabsWaitingToLoad[tabId];
+    }
+    if (!Object.keys(tabsWaitingToLoad).length) {
+      // We're done waiting for tabs to load, remove event listener
+      browser.tabs.onUpdated.removeListener(tabsOnUpdated);
+    }
+  };
+
+  // Query for already open Tabs
+  const tabs = await browser.tabs.query({});
+  tabs.map(async tab => {
+    if (tab.incognito) {
+      return;
+    }
+    if (tab.url === "about:blank") {
+      if (tab.status !== "loading") {
+        return;
+      }
+      // about:blank Tab is still loading, so we indicate that we wait for it to load
+      // and register the event listener if we haven't yet.
+      //
+      // This is a workaround until platform support is implemented:
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=1447551
+      // https://github.com/mozilla/multi-account-containers/issues/474
+      tabsWaitingToLoad[tab.id] = true;
+      if (!browser.tabs.onUpdated.hasListener(tabsOnUpdated)) {
+        browser.tabs.onUpdated.addListener(tabsOnUpdated);
+      }
+    } else {
+      // Tab already has an url, maybe we reopen
+      maybeReopenTab(tab);
+    }
+  });
+}
+
 async function containFacebook (options) {
   // Listen to requests and open Facebook into its Container,
   // open other sites into the default tab context
-  const requestUrl = new URL(options.url);
-
-  let isFacebook = false;
-  for (let facebookHostRE of facebookHostREs) {
-    if (facebookHostRE.test(requestUrl.host)) {
-      isFacebook = true;
-      break;
-    }
+  if (options.tabId === -1) {
+    // Request doesn't belong to a tab
+    return;
+  }
+  if (tabsWaitingToLoad[options.tabId]) {
+    // Cleanup just to make sure we don't get a race-condition with startup reopening
+    delete tabsWaitingToLoad[options.tabId];
   }
 
   // We have to check with every request if the requested URL is assigned with MAC
   // because the user can assign URLs at any given time (needs MAC Events)
-  if (macAddonEnabled) {
-    const macAssigned = await getMACAssignment(options.url);
-    if (macAssigned) {
-      // This URL is assigned with MAC, so we don't handle this request
-      return;
-    }
+  const macAssigned = await getMACAssignment(options.url);
+  if (macAssigned) {
+    // This URL is assigned with MAC, so we don't handle this request
+    return;
   }
 
   const tab = await browser.tabs.get(options.tabId);
-  const tabCookieStoreId = tab.cookieStoreId;
-  if (isFacebook) {
-    if (tabCookieStoreId !== facebookCookieStoreId && !tab.incognito) {
-      // See https://github.com/mozilla/contain-facebook/issues/23
-      // Sometimes this add-on is installed but doesn't get a facebookCookieStoreId ?
-      if (facebookCookieStoreId) {
-        if (shouldCancelEarly(tab, options)) {
-          return {cancel: true};
-        }
-        browser.tabs.create({
-          url: requestUrl.toString(),
-          cookieStoreId: facebookCookieStoreId,
-          active: tab.active,
-          index: tab.index,
-          windowId: tab.windowId
-        });
-        browser.tabs.remove(options.tabId);
-        return {cancel: true};
-      }
-    }
-  } else {
-    if (tabCookieStoreId === facebookCookieStoreId) {
-      if (shouldCancelEarly(tab, options)) {
-        return {cancel: true};
-      }
-      browser.tabs.create({
-        url: requestUrl.toString(),
-        active: tab.active,
-        index: tab.index,
-        windowId: tab.windowId
-      });
-      browser.tabs.remove(options.tabId);
-      return {cancel: true};
-    }
+  if (tab.incognito) {
+    // We don't handle incognito tabs
+    return;
   }
+
+  // Check whether we should contain this request into another container
+  const cookieStoreId = shouldContainInto(options.url, tab);
+  if (!cookieStoreId) {
+    // Request doesn't need to be contained
+    return;
+  }
+  if (shouldCancelEarly(tab, options)) {
+    // We need to cancel early to prevent multiple reopenings
+    return {cancel: true};
+  }
+  // Decided to contain
+  reopenTab({
+    url: options.url,
+    tab,
+    cookieStoreId
+  });
+  return {cancel: true};
 }
 
 (async function init() {
   await setupMACAddonManagementListeners();
   macAddonEnabled = await isMACAddonEnabled();
 
-  await setupContainer();
+  try {
+    await setupContainer();
+  } catch (error) {
+    // TODO: Needs backup strategy
+    // See https://github.com/mozilla/contain-facebook/issues/23
+    // Sometimes this add-on is installed but doesn't get a facebookCookieStoreId ?
+    // eslint-disable-next-line no-console
+    console.log(error);
+    return;
+  }
   clearFacebookCookies();
   generateFacebookHostREs();
-
-  // Add the request listener
-  browser.webRequest.onBeforeRequest.addListener(containFacebook, {urls: ["<all_urls>"], types: ["main_frame"]}, ["blocking"]);
 
   // Clean up canceled requests
   browser.webRequest.onCompleted.addListener((options) => {
     if (canceledRequests[options.tabId]) {
-     delete canceledRequests[options.tabId];
+      delete canceledRequests[options.tabId];
     }
   },{urls: ["<all_urls>"], types: ["main_frame"]});
   browser.webRequest.onErrorOccurred.addListener((options) => {
@@ -242,4 +340,9 @@ async function containFacebook (options) {
       delete canceledRequests[options.tabId];
     }
   },{urls: ["<all_urls>"], types: ["main_frame"]});
+
+  // Add the request listener
+  browser.webRequest.onBeforeRequest.addListener(containFacebook, {urls: ["<all_urls>"], types: ["main_frame"]}, ["blocking"]);
+
+  maybeReopenAlreadyOpenTabs();
 })();


### PR DESCRIPTION
Easy way to check: visit internet.org without this patch in Non-Facebook Container, check for www.facebook.com request in the DevTools, see cookie in the request header. Load with patch, repeat, cookie header gone

Rebased on #78 

Fixes #74 