### PR TITLE
Add workaround for web.whatsapp.com

### DIFF
--- a/background.js
+++ b/background.js
@@ -241,4 +241,14 @@ async function containFacebook (options) {
       delete canceledRequests[options.tabId];
     }
   },{urls: ["<all_urls>"], types: ["main_frame"]});
+
+  // web.whatsapp.com workaround, see #101
+  browser.tabs.onUpdated.addListener((tabId, changeInfo) => {
+    if (changeInfo.url && /^https?:\/\/web.whatsapp.com/.test(changeInfo.url)) {
+      containFacebook({
+        tabId,
+        url: changeInfo.url
+      })
+    }
+  })
 })();


### PR DESCRIPTION
An alternative might be using [webNavigation.onBeforeNavigate](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate) instead. However, since webNavigations aren't blockable, it wouldn't make much of a difference I guess.

Fixes #101 