### PR TITLE
Simplify storage clear; clears all data from all containers for jailed domains

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -31,26 +31,20 @@ async function isMACAddonEnabled () {
 }
 
 async function setupMACAddonManagementListeners () {
-  browser.management.onInstalled.addListener(info => {
-    if (info.id === MAC_ADDON_ID) {
-      macAddonEnabled = true;
-    }
-  });
-  browser.management.onUninstalled.addListener(info => {
+  function disabledExtension (info) {
     if (info.id === MAC_ADDON_ID) {
       macAddonEnabled = false;
     }
-  });
-  browser.management.onEnabled.addListener(info => {
+  }
+  function enabledExtension (info) {
     if (info.id === MAC_ADDON_ID) {
       macAddonEnabled = true;
     }
-  });
-  browser.management.onDisabled.addListener(info => {
-    if (info.id === MAC_ADDON_ID) {
-      macAddonEnabled = false;
-    }
-  });
+  }
+  browser.management.onInstalled.addListener(enabledExtension);
+  browser.management.onEnabled.addListener(enabledExtension);
+  browser.management.onUninstalled.addListener(disabledExtension);
+  browser.management.onDisabled.addListener(disabledExtension);
 }
 
 async function getMACAssignment (url) {
@@ -331,7 +325,7 @@ async function containFacebook (options) {
   return {cancel: true};
 }
 
-(async function init() {
+(async function init () {
   await setupMACAddonManagementListeners();
   macAddonEnabled = await isMACAddonEnabled();
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,9 +21,11 @@
 
     "permissions": [
         "<all_urls>",
+        "browsingData",
         "contextualIdentities",
         "cookies",
         "management",
+        "storage",
         "tabs",
         "webRequestBlocking",
         "webRequest"


### PR DESCRIPTION
This includes #127 to prevent conflicts. @groovecoder please note however new domains we will have to handle as migrations to be cleared with this code. This is due to the limitation of `browsingData` now having a `cookieStoreId` filter.

This however is still simpler if we want to clear all the storages fixed here.

I also removed the exemptions that were done with @stoically's code to clear assignments.

This however breaks the current test and I'm not sure on the best way to fix this.