### PR TITLE
fix #132: add storage permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,6 +25,7 @@
         "contextualIdentities",
         "cookies",
         "management",
+        "storage",
         "tabs",
         "webRequestBlocking",
         "webRequest"


### PR DESCRIPTION
We will need storage permission in a future release, and we only want to
interrupt the use with the prompt once.