### PR TITLE
add lookaside.fbsbx.com to the list of FB domains

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,7 +3,7 @@ const FACEBOOK_CONTAINER_NAME = "Facebook";
 const FACEBOOK_CONTAINER_COLOR = "blue";
 const FACEBOOK_CONTAINER_ICON = "briefcase";
 const FACEBOOK_DOMAINS = [
-  "facebook.com", "www.facebook.com", "fb.com", "fbcdn.net", "cdn.fbsbx.com",
+  "facebook.com", "www.facebook.com", "fb.com", "fbcdn.net", "cdn.fbsbx.com", "lookaside.fbsbx.com",
   "instagram.com", "www.instagram.com",
   "messenger.com", "www.messenger.com",
   "whatsapp.com", "www.whatsapp.com", "web.whatsapp.com", "cdn.whatsapp.net", "www-cdn.whatsapp.net",


### PR DESCRIPTION
This domain is where files uploaded to groups are served from.

(I got there when I opened such a file in the Windows 10 Facebook app)