### PR TITLE
Add "onavo.com" as facebook domain

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -7,7 +7,8 @@ const FACEBOOK_DOMAINS = [
   "instagram.com", "www.instagram.com",
   "messenger.com", "www.messenger.com",
   "whatsapp.com", "www.whatsapp.com", "web.whatsapp.com", "cdn.whatsapp.net", "www-cdn.whatsapp.net",
-  "atdmt.com"
+  "atdmt.com",
+  "onavo.com"
 ];
 
 const MAC_ADDON_ID = "@testpilot-containers";


### PR DESCRIPTION
[Onava](https://www.onavo.com) is a VPN service owned by facebook.