### PR TITLE
fix #178: strip fbclid from urls when reopening

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -310,7 +310,16 @@ async function maybeReopenAlreadyOpenTabs () {
   });
 }
 
+function stripFbclid(url) {
+  const strippedUrl = new URL(url);
+  strippedUrl.searchParams.delete("fbclid");
+  return strippedUrl.href;
+}
+
 async function containFacebook (options) {
+  if (options.url.includes("fbclid")) {
+    return {redirectUrl: stripFbclid(options.url)};
+  }
   // Listen to requests and open Facebook into its Container,
   // open other sites into the default tab context
   if (options.tabId === -1) {


### PR DESCRIPTION
This strips `fbclid` so it can't be used to link browsing sessions when tabs are re-opened inside-outside of Facebook Container.

However, I'm considering if we should *always* strip `fbclid` from all urls to cover a scenario where `fbclid` could link the uncontained context to an FB account with a link to a non-FB site.

E.g. an email notification contains a link to `https://www.example.com/?fbclid=12345` which embeds a request to `www.facebook.com`.

In that scenario, the embedded resource request from `example.com` to `facebook.com` includes the un-contained cookies and the `fbclid` value in the `Referer` header, which could effectively re-associate the un-contained cookies to the FB account.