### PR TITLE
Add Missing URLs

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,9 +3,12 @@ const FACEBOOK_CONTAINER_NAME = "Facebook";
 const FACEBOOK_CONTAINER_COLOR = "blue";
 const FACEBOOK_CONTAINER_ICON = "briefcase";
 const FACEBOOK_DOMAINS = [
-  "facebook.com", "www.facebook.com", "facebook.net", "fb.com", 
+  "facebook.com", "www.facebook.com", "facebook.net", "fb.com", "fb.me",
+  "facebookcorewwwi.onion", "fbcdn23dssr3jqnq.onion",
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
+  "f8.com",
+
 
   "instagram.com", 
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
@@ -15,7 +18,8 @@ const FACEBOOK_DOMAINS = [
   "atdmt.com",
 
   "onavo.com",
-  "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com"
+  "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com",
+  "lassovideos.com",
 ];
 
 const MAC_ADDON_ID = "@testpilot-containers";

--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,6 @@ const FACEBOOK_DOMAINS = [
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
   "f8.com",
 
-
   "instagram.com", 
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
 
@@ -20,6 +19,7 @@ const FACEBOOK_DOMAINS = [
   "onavo.com",
   "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com",
   "lassovideos.com",
+  "internet.org", 
 ];
 
 const MAC_ADDON_ID = "@testpilot-containers";


### PR DESCRIPTION
I have added the following URLs:
f8.com (Facebook's developer conference website)
lassovideos.com (Facebook's new video sharing platform)
internet.org (Facebook's "ISP")
facebookcorewwwi.onion (Facebook's Tor hidden service)
fbcdn23dssr3jqnq.onion (Facebook's Tor CDN)
