### PR TITLE
fix #227: change default_icon to the darker icon

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
 
     "browser_action": {
         "browser_style": true,
-        "default_icon": "fbc-icon.svg",
+        "default_icon": "fbc-icon2.svg",
         "default_title": "Facebook Container",
         "default_popup": "panel1.html",
         "theme_icons": [


### PR DESCRIPTION
Makes the icon show up when system (and therefore default Firefox) theme is in light mode ...

![image](https://user-images.githubusercontent.com/71928/54761736-a674fe80-4bc0-11e9-9b3b-e2fc430bb0c1.png)
