### PR TITLE
Add panel for Private Browsing

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,28 +1,22 @@
 <!--
-  Feel free to ignore this Issue template if you just want to ask or suggest something. If you experience an Issue then please provide all asked informations.
-
-  Note: If "Firefox will: Never remember history" in the Firefox Preferences/Options under "Privacy & Security > History" is selected, then Facebook Container will not work, since Containers aren't available in Private Windows.
+  Feel free to ignore this issue template if you just want to ask or suggest something. If you experience an issue then please provide all asked information.
 -->
-- Is "Firefox will: Never remember history" in the Firefox Preferences/Options under "Privacy & Security > History" selected? Yes/No:
-- Are you using Firefox in a Private Window? Yes/No:
-- Can you see a grayed out but ticked Checkbox with the description "Enable Container Tabs" in the Firefox Preferences/Options under "Tabs"? Yes/No:
 - Facebook Container Version:
 - Operating System + Version:
 - Firefox Version:
 - Other installed Add-ons + Version + Enabled/Disabled-Status:
-<!-- To be able to Copy&Paste the full list of your Add-ons navigate to "about:support" and scroll down to "Extensions" -->
+<!-- To be able to copy & paste the full list of your Add-ons navigate to "about:support" and scroll down to "Extensions" -->
 
 
 ### Actual behavior
-..
+
 
 ### Expected behavior
-..
+
 
 ### Steps to reproduce
-1. ..
-2. ..
-3. ..
+1.
+2.
+3.
 
 ### Notes
-..

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -34,5 +34,13 @@
     "onUnknownSiteHeader": {
         "message": "This site is not in the Facebook Container.",
         "description": "This is shown at the top of the panel pop-up when the user is on an \"unknown\" website - e.g., about:newtab. DO NOT TRANSLATE \"Facebook Container\"."
+    },
+    "privateBrowsingHeader": {
+        "message": "Not available in Private Browsing",
+        "description": "This is shown at the top of the panel pop-up when the user is in a Private Browsing window."
+    },
+    "privateBrowsingText": {
+        "message": "Facebook Container is not available in Private Browsing windows or if \"Never remember history\" is selected in the Firefox history options.",
+        "description": "This is shown in the body of the panel pop-up when the user is in a Private Browsing window. DO NOT TRANSLATE \"Facebook Container\"."
     }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -357,6 +357,10 @@ async function updateBrowserActionIcon (tab) {
     browser.browserAction.disable();
     return;
   }
+  if (tab.incognito) {
+    browser.browserAction.setPopup({tabId: tab.id, popup: "./panel-pb.html"});
+    return;
+  }
   if (isFacebookURL(url)) {
     browser.browserAction.setPopup({tabId: tab.id, popup: "./panel1.html"});
     const fbcStorage = await browser.storage.local.get();

--- a/src/panel-pb.html
+++ b/src/panel-pb.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <title>Facebook Container</title>
+    <link rel="stylesheet" href="panel.css">
+    <script src="panel.js"></script>
+  </head>
+  <body>
+    <div class="wrapper">
+      <h3 class="heading">
+        Facebook Container
+      </h3>
+      <p class="text"><b class="uiMessage" id="privateBrowsingHeader"></b></p>
+      <p class="text uiMessage" id="privateBrowsingText"></p>
+    </div>
+  </body>
+</html>

--- a/src/panel.js
+++ b/src/panel.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   const uiMessages = document.querySelectorAll(".uiMessage");
   for (const el of uiMessages) {
-    if (el.id.endsWith("Header") && currentActiveURL.hostname == "") {
+    if (el.id.endsWith("Header") && currentActiveURL.hostname == "" && !currentActiveTab.incognito) {
       el.textContent = browser.i18n.getMessage("onUnknownSiteHeader");
       continue;
     }


### PR DESCRIPTION
Explicit panel when user is in Private Browsing windows, otherwise the panels would be shown as if they're not in PB.

Could potentially be replaced by [`incognito: not_allowed`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito) starting with Firefox 67, but that would require setting `strict_min_version` to 67, otherwise the installation [fails for Firefox 66 users](https://bugzilla.mozilla.org/show_bug.cgi?id=1534107#c3).

Another alternative would of course be #240 and disable the popup in PB completely.