### PR TITLE
Update browserAction for active tab when initializing and window change

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -19,7 +19,12 @@ global.loadWebExtension = async (options = {}) => {
     sinon: global.sinon,
     background: {
       jsdom: {
-        beforeParse: options.beforeParse
+        beforeParse: window => {
+          window.browser.tabs._create({});
+          if (options.beforeParse) {
+            options.beforeParse(window);
+          }
+        }
       }
     }
   });


### PR DESCRIPTION
Fixes #228 

Removed the `await` from the call to `updateBrowserActionIcon` inside the request handler, because we don't need to wait for it to finish (and it does a `fetch` every time) in order to further process the request. Actually I'm not sure we need the call there at all, because the tabs.onUpdated listener fires in case the url changes anyway.