### PR TITLE
Disable browserAction in Private Browsing

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -351,6 +351,10 @@ async function areAllStringsTranslated () {
 }
 
 async function updateBrowserActionIcon (tab) {
+  if (tab.incognito) {
+    browser.browserAction.disable(tab.id);
+    return;
+  }
   const url = tab.url;
   const fullyTranslated = await areAllStringsTranslated();
   if (!fullyTranslated) {


### PR DESCRIPTION
Simple fix for the popup panel showing wrong information in private browsing (alternative to #232).