### PR TITLE
Add "in-fbc" panel.

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -3,6 +3,19 @@
         "message": "Facebook Container isolates your Facebook activity from the rest of your web activity in order to prevent Facebook from tracking you outside of the Facebook website via third party cookies.",
         "description": "Description of the extension. DO NOT TRANSLATE \"Facebook Container\"."
     },
+    "in-fbc-subhead": {
+      "message": "$URL$ is in the Facebook Container.",
+      "description": "This is shown at the top of the panel pop-up when the user is on a Facebook website, which has been automatically opened into Facebook Container. DO NOT TRANSLATE \"Facebook Container\".",
+      "placeholders": {
+          "url": {
+              "content": "$1",
+              "example": "www.facebook.com"
+          }
+      }
+    },
+    "in-fbc-p1": {
+      "message": "Facebook can now track you on this site. To remove this site from Facebook Container, select Sites Allowed in Facebook Container and remove it from the list."
+    },
     "on-facebook-subhead": {
         "message": "On Facebook and Sites in the Facebook Container Boundary",
         "description": "This is shown at the top of the panel pop-up when the user is on a Facebook website, which has been automatically opened into Facebook Container. DO NOT TRANSLATE \"Facebook Container\"."

--- a/src/background.js
+++ b/src/background.js
@@ -424,6 +424,8 @@ async function updateBrowserActionIcon (tab) {
     return;
   }
 
+  const hasBeenAddedToFacebookContainer = await isAddedToFacebookContainer(url);
+
   if (isFacebookURL(url)) {
     // TODO: change panel logic from browser.storage to browser.runtime.onMessage
     // so the panel.js can "ask" background.js which panel it should show
@@ -437,6 +439,8 @@ async function updateBrowserActionIcon (tab) {
       });
       browser.browserAction.setBadgeText({tabId: tab.id, text: " "});
     }
+  } else if (hasBeenAddedToFacebookContainer) {
+    browser.storage.local.set({"CURRENT_PANEL": "in-fbc"});
   } else { 
     const tabState = tabStates[tab.id];
     const panelToShow = (tabState && tabState.trackersDetected) ? "trackers-detected" : "no-trackers";

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -384,6 +384,7 @@ window.addEventListener("click", function(e){
   }
 });
 
+/*
 function removeBadges() {
   for (let itemClass of facebookDetectedElementsArr) {
     // positionFacebookBadge(item);
@@ -394,6 +395,7 @@ function removeBadges() {
     badge.parentNode.removeChild(badge);
   }
 }
+*/
 
 let checkForTrackers = true;
 
@@ -419,7 +421,7 @@ function contentScriptInit(resetSwitch, msg) {
   // callCount = callCount + 1;
   // console.log(call, callCount);
   // console.log(source, ": ", checkForTrackers);
-  console.log(msg);
+  // console.log(msg);
 
   if (resetSwitch) {
     contentScriptDelay = 999;
@@ -433,12 +435,10 @@ function contentScriptInit(resetSwitch, msg) {
   }
 }
 
-checkIfURLShouldBeBlocked(){
-  // TODO: Send current URL (or request directly from background.js) to check
-  // if the page needs to be searched for facebook elements. This fires BEFORE
-  // the background.js can check if the site is in the FBC.
+async function checkIfURLShouldBeBlocked() {
+  const siteList = await browser.runtime.sendMessage("what-sites-are-added");
 
-  if (true) {
+  if (siteList.includes(window.location.host)) {
     checkForTrackers = false;
   } else {
     contentScriptInit(false);

--- a/src/panel.css
+++ b/src/panel.css
@@ -258,6 +258,7 @@ a:hover {
   transition: var(--transition);
 }
 
+.in-fbc-subhead::before,
 .trackers-detected-subhead::before {
   background-image: url("/img/fenced-badge.svg");
   background-position: center center;
@@ -267,12 +268,10 @@ a:hover {
   margin-right: 3px;
 }
 
-.on-facebook-img {
+.img.in-fbc {
   background-image: url("/img/image-inFBC@2x.png");
-  height: 170px;
-  background-repeat: no-repeat;
-  display: block;
   background-position: bottom center;
+  height: 170px;
 }
 
 .img.trackers-detected {
@@ -296,6 +295,7 @@ a:hover {
 
 .img,
 .on-facebook-subbhead::before,
+.in-fbc-subhead::before,
 .highlight-on-hover::after,
 .Facebook-text::after,
 .trackers-detected-subhead::before,

--- a/src/panel.js
+++ b/src/panel.js
@@ -261,7 +261,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
 
 // Build non-onboarding panel
-const buildPanel = (panelId) => {
+const buildPanel = async(panelId) => {
   const { page, fragment } = setUpPanel(panelId);
   addHeader(fragment);
 
@@ -279,7 +279,7 @@ const buildPanel = (panelId) => {
     addParagraph(contentWrapper, `${panelId}-p2`);
   }
 
-  if (panelId === "trackers-detected") {
+  if (["trackers-detected", "in-fbc"].includes(panelId)) {
     addLearnMoreLink(contentWrapper);
     const imgDiv = addDiv(contentWrapper, panelId);
     imgDiv.classList.add("img");


### PR DESCRIPTION
Adds the "in-fbc" panel which should show when the user is on a site they've already added to the facebook container. This is a different panel than the one that shows when a user is on Facebook, or one of the other sites added by default.

I'm currently getting a "no-trackers" panelId message when visiting a site I've added to the container, so I think we may still need to set up a separate message for when someone is visiting a site they've previously added to the container. 