### PR TITLE
Non fb site breakage

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -13,6 +13,7 @@ const LOGIN_PATTERN_DETECTION_SELECTORS = [
   "[class*='facebook_login_click']", // Hi5
   "[class*='facebook-connect-button']", // Twitch
   "[href*='facebook.com/v2.3/dialog/oauth']", // Spotify
+  "[href*='/sign_in/Facebook']", // bazqux.com
   "[href*='signin/facebook']",
   "[data-oauthserver*='facebook']", // Stackoverflow
   "[id*='facebook_connect_button']", // Quora
@@ -446,8 +447,6 @@ let checkForTrackers = true;
 
 browser.runtime.onMessage.addListener(message => {
 
-  console.log("browser.runtime.onMessage: ", message["msg"]);
-
   if ( message["msg"] == "allowed-facebook-subresources" || message["msg"] == "facebook-domain" ) {
     // Flags function to not add badges to page
     checkForTrackers = false;
@@ -493,16 +492,6 @@ async function CheckIfURLShouldBeBlocked() {
   }
 
 }
-
-console.log("test");
-
-document.addEventListener('load', function() {
-  console.log('DOC: All assets are loaded');
-});
-
-window.addEventListener('load', function() {
-  console.log('All assets are loaded');
-});
 
 document.addEventListener("DOMContentLoaded", CheckIfURLShouldBeBlocked);
 // window.onload = contentScriptInit(false, "window.onload");

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -445,6 +445,9 @@ function removeBadges() {
 let checkForTrackers = true;
 
 browser.runtime.onMessage.addListener(message => {
+
+  console.log("browser.runtime.onMessage: ", message["msg"]);
+
   if ( message["msg"] == "allowed-facebook-subresources" || message["msg"] == "facebook-domain" ) {
     // Flags function to not add badges to page
     checkForTrackers = false;
@@ -480,7 +483,7 @@ function contentScriptInit(resetSwitch, msg) {
   }
 }
 
-async function checkIfURLShouldBeBlocked() {
+async function CheckIfURLShouldBeBlocked() {
   const siteList = await browser.runtime.sendMessage("what-sites-are-added");
 
   if (siteList.includes(window.location.host)) {
@@ -491,10 +494,17 @@ async function checkIfURLShouldBeBlocked() {
 
 }
 
-window.onload = checkIfURLShouldBeBlocked();
+console.log("test");
 
+document.addEventListener('load', function() {
+  console.log('DOC: All assets are loaded');
+});
 
-// document.addEventListener("DOMContentLoaded", contentScriptInit(false, "DOMContentLoaded"));
+window.addEventListener('load', function() {
+  console.log('All assets are loaded');
+});
+
+document.addEventListener("DOMContentLoaded", CheckIfURLShouldBeBlocked);
 // window.onload = contentScriptInit(false, "window.onload");
 // contentScriptSetTimeout();
 


### PR DESCRIPTION
Resolve sites that the FBC add-on break. 

Verified with the following sites:
+ https://www.modo.coop/plans/#tile-trip-calculator (Calculate trip) 
+ https://bazqux.com/ (Login w/ Facebook prompt) 
+ https://telemetry.mozilla.org/update-orphaning/ (Chart should animate/load)
+ https://air.mozilla.org/ (Login restored) 

Untested: 
+ https://sso.mozilla.com/workday (Login with Mozilla LDAP) 