### PR TITLE
Window.onload Overwrite Issue

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -528,8 +528,18 @@ async function CheckIfURLShouldBeBlocked() {
 
 }
 
-CheckIfURLShouldBeBlocked();
+// Cross-browser implementation of element.addEventListener()
+function passiveEventListener() {
+  const activeOnloadFunction = window.onload;
+  window.onload = function () {
+    if (typeof activeOnloadFunction == "function") {
+      activeOnloadFunction();
+    }
+    CheckIfURLShouldBeBlocked();
+  };
+}
 
+passiveEventListener();
 // window.onload = contentScriptInit(false, "window.onload");
 // contentScriptSetTimeout();
 

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -528,17 +528,17 @@ async function CheckIfURLShouldBeBlocked() {
 }
 
 // Cross-browser implementation of element.addEventListener()
-function passiveEventListener() {
+function addPassiveWindowOnloadListener() {
   const activeOnloadFunction = window.onload;
   window.onload = function () {
-    if (typeof activeOnloadFunction == "function") {
+    if (typeof activeOnloadFunction === "function") {
       activeOnloadFunction();
     }
     CheckIfURLShouldBeBlocked();
   };
 }
 
-passiveEventListener();
+addPassiveWindowOnloadListener();
 // window.onload = contentScriptInit(false, "window.onload");
 // contentScriptSetTimeout();
 

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -20,6 +20,7 @@ const LOGIN_PATTERN_DETECTION_SELECTORS = [
   "[data-destination*='facebook']",
   "[data-partner*='facebook']", // AliExpress
   ".social-login .button--facebook", // noovie.com
+  "#home_account_fb.unlogged-btn-facebook", // Deezer
   ".join-linkedin-form + .third-party-btn-container button.fb-btn", // LinkedIn
   ".fb-start .ybtn--social.ybtn--facebook", // Yelp
   "[aria-label*='Log in with Facebook']", // Tinder

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -503,7 +503,6 @@ function contentScriptInit(resetSwitch, msg) {
   // callCount = callCount + 1;
   // console.log(call, callCount);
   // console.log(source, ": ", checkForTrackers);
-  // console.log(msg);
 
   if (resetSwitch) {
     contentScriptDelay = 999;


### PR DESCRIPTION
## Summary 
I used the following snippet to solve the onload race condition/overwrite: https://www.systutorials.com/241284/add-my-own-window-onload-safely-without-overwriting-old-ones/ 

## Testing 

Test the following sites. _Note that unless noted, these should all happen without any scrolling/mouse clicks._ 

+ https://stackoverflow.com/users/login (SSO should get badged) 
+ https://telemetry.mozilla.org/update-orphaning (Graph should load, no badges) 
+ https://imgur.com/signin (SSO should get badged) 
+ https://www.buzzfeed.com/anamariaglavan/useful-products-youll-want-to-try-out-asap (Share buttons should get badged) 

Also added badge support for Deezer:
+ https://www.deezer.com/us/login 

## Screenshots

![image](https://user-images.githubusercontent.com/2692333/58038863-c197b800-7af6-11e9-9dba-8384eafcdf71.png)
