### PR TITLE
Remove duplicate share badges

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Facebook Container isolates your Facebook activity from the rest of your web activity in order to prevent Facebook from tracking you outside of the Facebook website via third party cookies. ",
   "main": "background.js",
   "scripts": {

--- a/src/content_script.css
+++ b/src/content_script.css
@@ -101,6 +101,21 @@
 	display: block;
 }
 
+/* Only show first Share badge   */
+
+.fbc-badge-share ~ .fbc-badge-share, .fbc-badge-share.fbc-badge-disabled, .fbc-badge-share:not(.fbc-badge-disabled) ~ .fbc-badge-share:not(.fbc-badge-disabled) {
+	display: none;
+	visibility: hidden;
+	opacity: 0;
+}
+
+.fbc-badge-share:not(.fbc-badge-disabled) {
+	display: block;
+	visibility: visible;
+	opacity: 1;
+}
+
+
 .fbc-badge-prompt {
 	display: none;
 	width: 345px;

--- a/src/content_script.css
+++ b/src/content_script.css
@@ -93,6 +93,10 @@
 	display: block;
 }
 
+.fbc-badge-share.fbc-badge-tooltip-active .fbc-badge-tooltip {
+	display: block;
+}
+
 .fbc-badge.active:hover .fbc-badge-tooltip {
 	display: none;
 }
@@ -103,17 +107,19 @@
 
 /* Only show first Share badge   */
 
-.fbc-badge-share ~ .fbc-badge-share, .fbc-badge-share.fbc-badge-disabled, .fbc-badge-share:not(.fbc-badge-disabled) ~ .fbc-badge-share:not(.fbc-badge-disabled) {
+.fbc-badge-share.fbc-badge-disabled, .fbc-badge-share:not(.fbc-badge-disabled):not(.fbc-badge-tooltip-active) ~ .fbc-badge-share:not(.fbc-badge-disabled):not(.fbc-badge-tooltip-active) {
 	display: none;
 	visibility: hidden;
 	opacity: 0;
 }
 
-.fbc-badge-share:not(.fbc-badge-disabled) {
+.fbc-badge-share:not(.fbc-badge-disabled), .fbc-badge-share.fbc-badge-tooltip-active:not(.fbc-badge-disabled) {
 	display: block;
 	visibility: visible;
 	opacity: 1;
 }
+
+
 
 
 .fbc-badge-prompt {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -340,7 +340,7 @@ function calcZindex(target) {
   }
 
   // Take highest zindex in parent tree and adds one more.
-  zIndexLevel = zIndexLevel + 1;
+  zIndexLevel = zIndexLevel + 2;
   return zIndexLevel;
 }
 

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -286,7 +286,9 @@ function getOffsetsAndApplyClass(elemRect, bodyRect, target, htmlBadgeDiv) {
     htmlBadgeDiv.classList.add("fbc-badge-fixed");
     return {offsetPosX: elemRect.left, offsetPosY: elemRect.top};
   } else {
-    return {offsetPosX: elemRect.left - bodyRect.left, offsetPosY: elemRect.top - bodyRect.top};
+    // Removed left body offset calc as it doesn't apply
+    // return {offsetPosX: elemRect.left - bodyRect.left, offsetPosY: elemRect.top - bodyRect.top};
+    return {offsetPosX: elemRect.left, offsetPosY: elemRect.top + window.scrollY};
   }
 }
 
@@ -316,10 +318,10 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
 function determineContainerClientRect() {
   const htmlHeight = document.querySelector("html").offsetHeight;
   const bodyHeight = document.querySelector("body").offsetHeight;
-  // console.log([htmlHeight, bodyHeight]);
+  // console.log([htmlHeight, bodyHeight, (htmlHeight > bodyHeight)]);
   if (htmlHeight === bodyHeight) {
     return document.body.getBoundingClientRect();
-  } else if ( htmlHeight > bodyHeight ) {
+  } else if ( htmlHeight < bodyHeight ) {
     return document.querySelector("html").getBoundingClientRect();
   } else {
     return document.body.getBoundingClientRect();

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -306,15 +306,17 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
     return;
   }
 
-  const parentIsHidden = (target.offsetParent === null);
-
-  if ( parentIsHidden && !htmlBadgeDivHasDisabledClass ) {
-    // Parent isnt visible and its badge needs to be hidden
-    htmlBadgeDiv.classList.add("fbc-badge-disabled");
-  }
-
-  if ( !parentIsHidden && !targetIsNull && htmlBadgeDivHasDisabledClass ||  !parentIsHidden && htmlBadgeDivHasDisabledClass ) {
-    htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+  const { offsetParent } = target;
+  if (offsetParent) {
+    const styleTransform = ( window.getComputedStyle(offsetParent, false).getPropertyValue("transform") === "matrix(1, 0, 0, 0, 0, 0)" );
+    // console.log(styleTransform);
+    if (styleTransform && !htmlBadgeDivHasDisabledClass) {
+      htmlBadgeDiv.classList.add("fbc-badge-disabled");
+    }
+  } else {
+    if ( htmlBadgeDivHasDisabledClass ) {
+      htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+    }
   }
 
 }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -212,18 +212,15 @@ function addFacebookBadge (target, badgeClassUId, socialAction) {
     });
 
     target.addEventListener("mouseover", () => {
+      // console.log(["mouseover", target, htmlBadgeDiv]);
       target.classList.add("fbc-badge-tooltip-active");
       htmlBadgeDiv.classList.add("fbc-badge-tooltip-active");
-      // console.log(["mouseover", target, htmlBadgeDiv]);
-      // positionPrompt( htmlBadgeDiv );
     });
 
     target.addEventListener("mouseout", () => {
       // console.log(["mouseout", target, htmlBadgeDiv]);
       target.classList.remove("fbc-badge-tooltip-active");
       htmlBadgeDiv.classList.remove("fbc-badge-tooltip-active");
-
-      // positionPrompt( htmlBadgeDiv );
     });
 
   }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -204,10 +204,28 @@ function addFacebookBadge (target, badgeClassUId, socialAction) {
       e.target.parentElement.parentNode.parentNode.classList.remove("active");
     });
   } else if (socialAction === "share") {
+    htmlBadgeDiv.classList.add("fbc-badge-share");
+
     target.addEventListener("click", (e) => {
       e.preventDefault();
       e.stopPropagation();
     });
+
+    target.addEventListener("mouseover", () => {
+      target.classList.add("fbc-badge-tooltip-active");
+      htmlBadgeDiv.classList.add("fbc-badge-tooltip-active");
+      // console.log(["mouseover", target, htmlBadgeDiv]);
+      // positionPrompt( htmlBadgeDiv );
+    });
+
+    target.addEventListener("mouseout", () => {
+      // console.log(["mouseout", target, htmlBadgeDiv]);
+      target.classList.remove("fbc-badge-tooltip-active");
+      htmlBadgeDiv.classList.remove("fbc-badge-tooltip-active");
+
+      // positionPrompt( htmlBadgeDiv );
+    });
+
   }
 
   // Applies to both!

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -215,6 +215,9 @@ function addFacebookBadge (target, badgeClassUId, socialAction) {
       // console.log(["mouseover", target, htmlBadgeDiv]);
       target.classList.add("fbc-badge-tooltip-active");
       htmlBadgeDiv.classList.add("fbc-badge-tooltip-active");
+      setTimeout( ()=> {
+        positionPrompt( htmlBadgeDiv );
+      }, 50 );
     });
 
     target.addEventListener("mouseout", () => {
@@ -253,6 +256,7 @@ function positionPrompt ( activeBadge ) {
   // const activeBadge = document.querySelector(".fbc-badge-prompt");
   // const activeBadgePrompt = activeBadge.querySelector(".fbc-badge-prompt");
   const elemRect = activeBadge.getBoundingClientRect();
+  // console.log(elemRect);
 
   if ( (window.innerWidth - elemRect.left) < 350  ) {
     activeBadge.classList.add("fbc-badge-prompt-align-right");

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Facebook Container",
-    "version": "1.9.1",
+    "version": "1.9.2",
 
     "default_locale": "en",
 


### PR DESCRIPTION
Check the following sites: 

To test – You should only see ONE share badge per page. On any other FB share buttons, hover over button to make that badge appear. 

+ https://www.estadao.com.br/
+ https://www.theguardian.com/commentisfree/2019/may/24/next-tory-leader-panel-theresa-may-conservatives#comments
+ https://www.buzzfeed.com/bekoconnell/cheap-products-everything-50
