### PR TITLE
Prevent window.onload from being run twice

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -546,12 +546,7 @@ async function CheckIfURLShouldBeBlocked() {
 
 // Cross-browser implementation of element.addEventListener()
 function addPassiveWindowOnloadListener() {
-  const activeOnloadFunction = window.onload;
   window.addEventListener("load", function() {
-  // window.onload = function () {
-    if (typeof activeOnloadFunction === "function") {
-      activeOnloadFunction();
-    }
     CheckIfURLShouldBeBlocked();
   }, false);
 }


### PR DESCRIPTION
Do not call window.onload function from the load event listener: this causes the onload function to run twice, which breaks some websites.
Fixes #420

Example HTML which shows that the window.onload function is run twice before this patch:
```
<!doctype html>
<html>
<head></head>
<body>
<!-- Load an external resource to cause the onload event to trigger after a delay -->
<img src="https://avatars0.githubusercontent.com/u/104874?s=88&v=4">
<script>
times = 0;
window.onload = function() {
  console.log(++times + ": onload called");
};
</script>
</body>
</html>
```
The console will display the following with 1.9.1:
```
1: onload called
2: onload called
```