### PR TITLE
Fixed #389, Cleans up badges from no-longer-active elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "1.6.5",
+  "version": "2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/content_script.css
+++ b/src/content_script.css
@@ -313,7 +313,12 @@
 
 .fbc-badge-prompt-align-right .fbc-badge-tooltip {
 	left: auto;
-	right: calc( 100% + 20px );
+	right: calc( 100% + 0.5em );
+}
+
+.fbc-badge-prompt-align-bottom .fbc-badge-tooltip {
+	top: auto;
+	bottom: 25%;
 }
 
 /* .fbc-badge-prompt-align-right .fbc-badge-prompt {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -58,6 +58,14 @@ function isFixed (elem) {
   return false;
 }
 
+function isDisplayNone (elem) {
+  do {
+    const displayStyle = getComputedStyle(elem).getPropertyValue("display");
+    if (getComputedStyle(elem).getPropertyValue("display") == "none") return true;
+  } while ((elem = elem.offsetParent));
+  return false;
+}
+
 const fragmentClasses = ["fbc-badge-fence", "fbc-badge-tooltip", "fbc-badge-prompt"];
 const htmlBadgeFragmentPromptParagraphStrings = [ browser.i18n.getMessage("inPageUI-tooltip-prompt-p1"), browser.i18n.getMessage("inPageUI-tooltip-prompt-p2") ];
 const htmlBadgeFragmentPromptButtonStrings = ["btn-cancel", "btn-allow"];
@@ -310,6 +318,11 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
   }
 
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
+
+  if (isDisplayNone(target) && !htmlBadgeDivHasDisabledClass) {
+    htmlBadgeDiv.classList.add("fbc-badge-disabled");
+    return false;
+  }
 
   const { parentElement } = target;
   if (parentElement) {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -299,12 +299,11 @@ function getOffsetsAndApplyClass(elemRect, bodyRect, target, htmlBadgeDiv) {
 }
 
 function isVisible(target) {
-  const styleTransform = ( window.getComputedStyle(target, false).getPropertyValue("transform") === "matrix(1, 0, 0, 0, 0, 0)" );
-  const styleHidden = ( window.getComputedStyle(target, false).getPropertyValue("visibility") === "hidden" );
-  const styleDisplayNone = ( window.getComputedStyle(target, false).getPropertyValue("display") === "none" );
-  if (styleTransform || styleHidden || styleDisplayNone){
-    return false;
-  }
+  const currentComputedStyle = window.getComputedStyle(target, false);
+  const styleTransform = ( currentComputedStyle.getPropertyValue("transform") === "matrix(1, 0, 0, 0, 0, 0)" );
+  const styleHidden = ( currentComputedStyle.getPropertyValue("visibility") === "hidden" );
+  const styleDisplayNone = ( currentComputedStyle.getPropertyValue("display") === "none" );
+  if (styleTransform || styleHidden || styleDisplayNone) return false;
   return true;
 }
 

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -59,11 +59,6 @@ function isFixed (elem) {
   return false;
 }
 
-function isDisplayNone (target) {
-  if ( getComputedStyle(target, null).display === "none" ) return true;
-  return false;
-}
-
 const fragmentClasses = ["fbc-badge-fence", "fbc-badge-tooltip", "fbc-badge-prompt"];
 const htmlBadgeFragmentPromptParagraphStrings = [ browser.i18n.getMessage("inPageUI-tooltip-prompt-p1"), browser.i18n.getMessage("inPageUI-tooltip-prompt-p2") ];
 const htmlBadgeFragmentPromptButtonStrings = ["btn-cancel", "btn-allow"];
@@ -318,7 +313,7 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
 
 
 
-  if (isDisplayNone(target)) {
+  if (!isVisible(target)) {
     if (!htmlBadgeDivHasDisabledClass) {
       htmlBadgeDiv.classList.add("fbc-badge-disabled");
     }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -60,7 +60,6 @@ function isFixed (elem) {
 
 function isDisplayNone (elem) {
   do {
-    const displayStyle = getComputedStyle(elem).getPropertyValue("display");
     if (getComputedStyle(elem).getPropertyValue("display") == "none") return true;
   } while ((elem = elem.offsetParent));
   return false;
@@ -320,7 +319,7 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
   if (isDisplayNone(target) && !htmlBadgeDivHasDisabledClass) {
-    console.log("isDisplayNone");
+    // console.log("isDisplayNone");
     htmlBadgeDiv.classList.add("fbc-badge-disabled");
     return false;
   }
@@ -403,13 +402,9 @@ function positionFacebookBadge (target, badgeClassUId, targetWidth, smallSwitch)
     target = document.querySelector("." + target);
   }
 
-  // checkVisibilityAndApplyClass(target, htmlBadgeDiv);
-
   if (!checkVisibilityAndApplyClass(target, htmlBadgeDiv)) {
     return;
   }
-
-  console.log("past-visibility-check");
 
   if (typeof smallSwitch === "undefined") {
     if (htmlBadgeDiv.classList.contains("fbc-badge-small")) {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -320,35 +320,40 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
   if (isDisplayNone(target) && !htmlBadgeDivHasDisabledClass) {
+    console.log("isDisplayNone");
     htmlBadgeDiv.classList.add("fbc-badge-disabled");
     return false;
   }
 
   const { parentElement } = target;
   if (parentElement) {
-    if ( !isVisible(parentElement) && !htmlBadgeDivHasDisabledClass) {
-      htmlBadgeDiv.classList.add("fbc-badge-disabled");
+    if ( !isVisible(parentElement) ) {
+      if (!htmlBadgeDivHasDisabledClass) {
+        htmlBadgeDiv.classList.add("fbc-badge-disabled");
+      }
       return false;
-    }
-  } else {
-    if ( htmlBadgeDivHasDisabledClass ) {
-      htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+    } else {
+      if ( htmlBadgeDivHasDisabledClass ) {
+        htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+        return true;
+      }
     }
   }
 
   const { offsetParent } = target;
   if (offsetParent) {
-    if ( !isVisible(parentElement) && !htmlBadgeDivHasDisabledClass) {
-      htmlBadgeDiv.classList.add("fbc-badge-disabled");
+    if ( !isVisible(parentElement)) {
+      if (!htmlBadgeDivHasDisabledClass) {
+        htmlBadgeDiv.classList.add("fbc-badge-disabled");
+      }
       return false;
-    }
-  } else {
-    if ( htmlBadgeDivHasDisabledClass ) {
-      htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+    } else {
+      if ( htmlBadgeDivHasDisabledClass ) {
+        htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+        return true;
+      }
     }
   }
-
-  return true;
 
 }
 
@@ -403,6 +408,8 @@ function positionFacebookBadge (target, badgeClassUId, targetWidth, smallSwitch)
   if (!checkVisibilityAndApplyClass(target, htmlBadgeDiv)) {
     return;
   }
+
+  console.log("past-visibility-check");
 
   if (typeof smallSwitch === "undefined") {
     if (htmlBadgeDiv.classList.contains("fbc-badge-small")) {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -293,6 +293,16 @@ function getOffsetsAndApplyClass(elemRect, bodyRect, target, htmlBadgeDiv) {
   }
 }
 
+function isVisible(target) {
+  const styleTransform = ( window.getComputedStyle(target, false).getPropertyValue("transform") === "matrix(1, 0, 0, 0, 0, 0)" );
+  const styleHidden = ( window.getComputedStyle(target, false).getPropertyValue("visibility") === "hidden" );
+  const styleDisplayNone = ( window.getComputedStyle(target, false).getPropertyValue("display") === "none" );
+  if (styleTransform || styleHidden || styleDisplayNone){
+    return false;
+  }
+  return true;
+}
+
 function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
 
   if ( target === null ) {
@@ -302,11 +312,10 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
 
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
-  const { offsetParent } = target;
-  if (offsetParent) {
-    const styleTransform = ( window.getComputedStyle(offsetParent, false).getPropertyValue("transform") === "matrix(1, 0, 0, 0, 0, 0)" );
-    // console.log(styleTransform);
-    if (styleTransform && !htmlBadgeDivHasDisabledClass) {
+  const { parentElement } = target;
+
+  if (parentElement) {
+    if ( !isVisible(parentElement) && !htmlBadgeDivHasDisabledClass) {
       htmlBadgeDiv.classList.add("fbc-badge-disabled");
       return false;
     }
@@ -315,6 +324,19 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
       htmlBadgeDiv.classList.remove("fbc-badge-disabled");
     }
   }
+
+  const { offsetParent } = target;
+  if (offsetParent) {
+    if ( !isVisible(parentElement) && !htmlBadgeDivHasDisabledClass) {
+      htmlBadgeDiv.classList.add("fbc-badge-disabled");
+      return false;
+    }
+  } else {
+    if ( htmlBadgeDivHasDisabledClass ) {
+      htmlBadgeDiv.classList.remove("fbc-badge-disabled");
+    }
+  }
+
   return true;
 
 }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -12,6 +12,7 @@ const LOGIN_PATTERN_DETECTION_SELECTORS = [
   "[class*='btn-facebook-signin']", // estadao.com.br
   "[class*='signup-provider-facebook']", // Fandom
   "[class*='facebook_login_click']", // Hi5
+  "[class*='facebook-signup-button']", // Strava
   "[class*='facebook-connect-button']", // Twitch
   "[href*='facebook.com/v2.3/dialog/oauth']", // Spotify
   "[href*='/sign_in/Facebook']", // bazqux.com
@@ -319,7 +320,6 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
   if (isDisplayNone(target) && !htmlBadgeDivHasDisabledClass) {
-    // console.log("isDisplayNone");
     htmlBadgeDiv.classList.add("fbc-badge-disabled");
     return false;
   }
@@ -334,8 +334,8 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
     } else {
       if ( htmlBadgeDivHasDisabledClass ) {
         htmlBadgeDiv.classList.remove("fbc-badge-disabled");
-        return true;
       }
+      return true;
     }
   }
 
@@ -349,11 +349,11 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
     } else {
       if ( htmlBadgeDivHasDisabledClass ) {
         htmlBadgeDiv.classList.remove("fbc-badge-disabled");
-        return true;
       }
+      return true;
     }
   }
-
+  return true;
 }
 
 function determineContainerClientRect() {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -252,9 +252,6 @@ function closePrompt() {
 }
 
 function positionPrompt ( activeBadge ) {
-  // console.log(activeBadge);
-  // const activeBadge = document.querySelector(".fbc-badge-prompt");
-  // const activeBadgePrompt = activeBadge.querySelector(".fbc-badge-prompt");
   const elemRect = activeBadge.getBoundingClientRect();
   // console.log(elemRect);
 
@@ -297,14 +294,13 @@ function getOffsetsAndApplyClass(elemRect, bodyRect, target, htmlBadgeDiv) {
 }
 
 function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
-  const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
-  const targetIsNull = (target === null);
 
-  if ( targetIsNull && !htmlBadgeDivHasDisabledClass ) {
-    // Element no longer exists and its badge needs to be hidden
+  if ( target === null ) {
     htmlBadgeDiv.classList.add("fbc-badge-disabled");
-    return;
+    return false;
   }
+
+  const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
   const { offsetParent } = target;
   if (offsetParent) {
@@ -312,12 +308,14 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
     // console.log(styleTransform);
     if (styleTransform && !htmlBadgeDivHasDisabledClass) {
       htmlBadgeDiv.classList.add("fbc-badge-disabled");
+      return false;
     }
   } else {
     if ( htmlBadgeDivHasDisabledClass ) {
       htmlBadgeDiv.classList.remove("fbc-badge-disabled");
     }
   }
+  return true;
 
 }
 
@@ -352,7 +350,9 @@ function calcZindex(target) {
   return zIndexLevel;
 }
 
+
 function positionFacebookBadge (target, badgeClassUId, targetWidth, smallSwitch) {
+
   // Check for Badge element and select it
   if (!badgeClassUId) {
     badgeClassUId = "js-" + target;
@@ -365,7 +365,11 @@ function positionFacebookBadge (target, badgeClassUId, targetWidth, smallSwitch)
     target = document.querySelector("." + target);
   }
 
-  checkVisibilityAndApplyClass(target, htmlBadgeDiv);
+  // checkVisibilityAndApplyClass(target, htmlBadgeDiv);
+
+  if (!checkVisibilityAndApplyClass(target, htmlBadgeDiv)) {
+    return;
+  }
 
   if (typeof smallSwitch === "undefined") {
     if (htmlBadgeDiv.classList.contains("fbc-badge-small")) {
@@ -439,6 +443,7 @@ function patternDetection(selectionArray, socialActionIntent){
         addFacebookBadge(item, itemUIDClassTarget, socialAction);
         item.classList.add("fbc-has-badge");
         item.classList.add(itemUIDClassName);
+        // console.log(itemUIDClassName);
       }
     }
   }
@@ -545,12 +550,14 @@ function contentScriptInit(resetSwitch, msg) {
   // console.log(source, ": ", checkForTrackers);
 
   if (resetSwitch) {
+    // console.log("contentScriptInit--resetSwitch");
     contentScriptDelay = 999;
     contentScriptSetTimeout();
   }
 
   // Resource call is not in FBC/FB Domain and is a FB resource
   if (checkForTrackers && msg !== "other-domain") {
+    // console.log("contentScriptInit--resource");
     detectFacebookOnPage();
     screenUpdate();
   }
@@ -575,10 +582,11 @@ function addPassiveWindowOnloadListener() {
 }
 
 addPassiveWindowOnloadListener();
-// window.onload = contentScriptInit(false, "window.onload");
-// contentScriptSetTimeout();
 
 function contentScriptSetTimeout() {
+  // console.timeEnd('contentScriptSetTimeout');
+  // console.timeStart('contentScriptSetTimeout');
+  // console.log("contentScriptSetTimeout");
   contentScriptDelay = Math.ceil(contentScriptDelay * 2);
   contentScriptInit(false);
   if ( contentScriptDelay > 999999 ) {

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -253,7 +253,6 @@ function closePrompt() {
 
 function positionPrompt ( activeBadge ) {
   const elemRect = activeBadge.getBoundingClientRect();
-  // console.log(elemRect);
 
   if ( (window.innerWidth - elemRect.left) < 350  ) {
     activeBadge.classList.add("fbc-badge-prompt-align-right");
@@ -313,7 +312,6 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
   const { parentElement } = target;
-
   if (parentElement) {
     if ( !isVisible(parentElement) && !htmlBadgeDivHasDisabledClass) {
       htmlBadgeDiv.classList.add("fbc-badge-disabled");

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -59,10 +59,8 @@ function isFixed (elem) {
   return false;
 }
 
-function isDisplayNone (elem) {
-  do {
-    if (getComputedStyle(elem).getPropertyValue("display") == "none") return true;
-  } while ((elem = elem.offsetParent));
+function isDisplayNone (target) {
+  if ( getComputedStyle(target, null).display === "none" ) return true;
   return false;
 }
 
@@ -319,8 +317,12 @@ function checkVisibilityAndApplyClass(target, htmlBadgeDiv) {
 
   const htmlBadgeDivHasDisabledClass = htmlBadgeDiv.classList.contains("fbc-badge-disabled");
 
-  if (isDisplayNone(target) && !htmlBadgeDivHasDisabledClass) {
-    htmlBadgeDiv.classList.add("fbc-badge-disabled");
+
+
+  if (isDisplayNone(target)) {
+    if (!htmlBadgeDivHasDisabledClass) {
+      htmlBadgeDiv.classList.add("fbc-badge-disabled");
+    }
     return false;
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Facebook Container",
-    "version": "1.9.2",
+    "version": "2.0",
 
     "default_locale": "en",
 


### PR DESCRIPTION
Test the following sites: 

+ #406 – https://lifehacker.com/what-to-do-if-you-miss-your-flight-1834889383 (Hover over fixed Facebook button at bottom right of page. Tooltip should be visible) 
+ #424 – haaretz.com (Should not have floating badge in navigation) 
+ #425 – https://medium.com/mofed/css-line-clamp-the-good-the-bad-and-the-straight-up-broken-865413f16e5 (Should not have floating badge to left of article content) 