### PR TITLE
Add workplace domain to background js

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -9,14 +9,14 @@ const FACEBOOK_DOMAINS = [
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
 
-  "workplace.com", "www.workplace.com", "work.facebook.com",
-
   "instagram.com",
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
 
   "messenger.com", "m.me", "messengerdevelopers.com",
 
   "atdmt.com",
+
+  "workplace.com", "www.workplace.com", "work.facebook.com",
 
   "onavo.com",
   "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com"

--- a/src/background.js
+++ b/src/background.js
@@ -9,6 +9,8 @@ const FACEBOOK_DOMAINS = [
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
 
+  "workplace.com", "www.workplace.com", "work.facebook.com",
+
   "instagram.com",
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
 


### PR DESCRIPTION
## Summary: 

Added "workplace.com" domains to the background.js to open inside the Facebook Container. 

## Test

+ Visit  [workplace.com](https://workplace.com)
+ Visit [work.facebook.com](https://work.facebook.com)

Both of these URLs should open inside the Facebook Contianer. 

## Build Files
https://send.firefox.com/download/26f42108e4ebbd14/#q9ptmTfz5G6NpodttmmmXQ
