### PR TITLE
Fixed #468 – Added login support to Wish.com

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -19,6 +19,7 @@ const LOGIN_PATTERN_DETECTION_SELECTORS = [
   "[class*='facebook_login_click']", // Hi5
   "[class*='facebook-signup-button']", // Strava
   "[class*='facebook-connect-button']", // Twitch
+  "[class*='AuthenticationModal__FacebookButtonWrapper']", // Twitch
   "[href*='facebook.com/v2.3/dialog/oauth']", // Spotify
   "[href*='/sign_in/Facebook']", // bazqux.com
   "[href*='signin/facebook']",


### PR DESCRIPTION
## Testing Steps: 

- Go to https://wish.com
- Badge should appear "Sign up with Facebook"
- Click "Login" 
- Badge should appear about "Login with Facebook"

## Screenshots: 

![image](https://user-images.githubusercontent.com/2692333/60899518-3900e280-a230-11e9-89a4-0df6da462c96.png)

![image](https://user-images.githubusercontent.com/2692333/60899518-3900e280-a230-11e9-89a4-0df6da462c96.png)


