### PR TITLE
Fixed #467 - Added additional FB owned domains to the default list

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -9,6 +9,8 @@ const FACEBOOK_DOMAINS = [
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
 
+  "facebookblueprint.com", "accountkit.com","f8.com",
+
   "instagram.com",
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
 


### PR DESCRIPTION
## Testing Steps

The following domains should all automatically open inside the Facebook container. 
-  https://facebookblueprint.com
-  https://www.accountkit.com
-  https://www.f8.com

