### PR TITLE
Disable extension in incognito mode

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,8 @@
     "name": "Facebook Container",
     "version": "2.0.3",
 
+    "incognito": "not_allowed",
+    
     "default_locale": "en",
 
     "description": "__MSG_extensionDescription__",


### PR DESCRIPTION
The extension's functionality should resemble the Multi-Account Containers and be disabled in Incognito mode.