### PR TITLE
Add instagram-press.com to Instagram domains

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,7 @@ const FACEBOOK_DOMAINS = [
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
 
-  "instagram.com",
+  "instagram.com", "instagram-press.com",
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
 
   "messenger.com", "m.me", "messengerdevelopers.com",


### PR DESCRIPTION
`instagram-press.com` is missing