### PR TITLE
Perf: Join the selectors and call querySelectorAll() only once

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -473,20 +473,20 @@ const facebookDetectedElementsArr = [];
 
 function patternDetection(selectionArray, socialActionIntent){
   // console.log("patternDetection");
-  for (let querySelector of selectionArray) {
-    for (let item of document.querySelectorAll(querySelector)) {
-      // overlay the FBC icon badge on the item
-      if (!item.classList.contains("fbc-has-badge") && !isPinterest(item) && !parentIsBadged(item)) {
-        // console.log([querySelector, item]);
-        const itemUIDClassName = "fbc-UID_" + (facebookDetectedElementsArr.length + 1);
-        const itemUIDClassTarget = "js-" + itemUIDClassName;
-        const socialAction = socialActionIntent;
-        facebookDetectedElementsArr.push(itemUIDClassName);
-        addFacebookBadge(item, itemUIDClassTarget, socialAction);
-        item.classList.add("fbc-has-badge");
-        item.classList.add(itemUIDClassName);
-        // console.log(itemUIDClassName);
-      }
+  let querySelector = selectionArray.join(",");
+
+  for (let item of document.querySelectorAll(querySelector)) {
+    // overlay the FBC icon badge on the item
+    if (!item.classList.contains("fbc-has-badge") && !isPinterest(item) && !parentIsBadged(item)) {
+      // console.log([querySelector, item]);
+      const itemUIDClassName = "fbc-UID_" + (facebookDetectedElementsArr.length + 1);
+      const itemUIDClassTarget = "js-" + itemUIDClassName;
+      const socialAction = socialActionIntent;
+      facebookDetectedElementsArr.push(itemUIDClassName);
+      addFacebookBadge(item, itemUIDClassTarget, socialAction);
+      item.classList.add("fbc-has-badge");
+      item.classList.add(itemUIDClassName);
+      // console.log(itemUIDClassName);
     }
   }
 }


### PR DESCRIPTION
Calling querySelectorAll() in a loop may traverse the DOM tree multiple times. This can be very slow on complex websites[1]. Based on Gecko profiler, joining the selectors and calling querySelectorAll() only once can be over twice as fast[2]. 

[1]: For example, https://hg.mozilla.org/releases/mozilla-release/file/tip/layout/painting/FrameLayerBuilder.cpp
[2]: before https://perfht.ml/2PgcPYf, after https://perfht.ml/2N5qSNx