### PR TITLE
Fixed #586 - Added missing strings

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -213,6 +213,14 @@
      "message": " If you want to use Log in with Facebook again, you will need to add it back to the Facebook Container.",
      "description": ""
    },
+   "add-site-subhead": {
+      "message": "Allow Facebook Tracking on this Site?",
+      "description": ""
+   },
+   "add-site-p1": {
+     "message": "This lets you log in with Facebook, but allows Facebook to follow what you do on this site.",
+     "description": ""
+   },
    "inPageUI-tooltip-button-share": {
      "message": "Facebook Container has disabled this button and blocked Facebook from tracking your visit to this page.",
      "description": ""


### PR DESCRIPTION
There was a missing interstitial panel during the "adding site" process of the new site management feature. These strings account for it. See additional info in [the issue](https://github.com/mozilla/contain-facebook/issues/586).  