### PR TITLE
Fixed #585 - Added confirmation interstitial when adding/removing sites from the container 

### DIFF
--- a/src/panel.css
+++ b/src/panel.css
@@ -221,7 +221,7 @@ a:hover {
   transition: var(--transition);
 }
 
-.remove-btn {
+.remove-btn, .allow-btn {
   background-color: var(--blue60);
   border: 1px solid var(--blue60);
   border-top: 1px solid var(--blue70);
@@ -232,11 +232,11 @@ a:hover {
   font-size: 13px;
 }
 
-.remove-btn:hover {
+.remove-btn:hover, .allow-btn:hover {
   background-color: var(--blue70);
 }
 
-.remove-site {
+.remove-site, .add-site {
   background-color: transparent;
   border: none;
   position: absolute;
@@ -249,12 +249,12 @@ a:hover {
   cursor: pointer;
 }
 
-.remove-site-panel .allowed-site-wrapper {
+.remove-site-panel .allowed-site-wrapper, .add-site-panel .allowed-site-wrapper {
   padding: 0;
   margin-bottom: 1rem;
 }
 
-.remove-site-panel .allowed-site-wrapper:hover {
+.remove-site-panel .allowed-site-wrapper:hover, .add-site-panel .allowed-site-wrapper:hover {
   background-color: transparent;
 }
 
@@ -311,6 +311,8 @@ a:hover {
   background-color: var(--blue70);
 }
 
+.allow-btn,
+.allow-btn:hover,
 .remove-btn,
 .remove-btn:hover,
 .bottom-btn,

--- a/src/panel.js
+++ b/src/panel.js
@@ -187,7 +187,7 @@ const setCustomSiteButtonEvent = async (panelId) => {
   }
 
   // Active site is eligable to be added to the container
-  addSiteToContainerLink.addEventListener("click", async () => addSiteToContainer());
+  addSiteToContainerLink.addEventListener("click", async () => buildAddSitePanel());
 };
 
 // adds bottom navigation buttons to onboarding panels

--- a/src/panel.js
+++ b/src/panel.js
@@ -178,7 +178,7 @@ const setCustomSiteButtonEvent = async (panelId) => {
   }
 
   const addSiteToContainerLink = document.querySelector(".add-site-to-container");
-  addSiteToContainerLink.addEventListener("click", async () => addSiteToContainer());
+  addSiteToContainerLink.addEventListener("click", async () => buildAddSitePanel());
 
 };
 
@@ -529,19 +529,49 @@ const buildAllowedSitesPanel = async(panelId) => {
 
 const removeSiteFromContainer = async () => {
   const activeHostname = await getActiveHostname();
-  await browser.runtime.sendMessage( {removeDomain: activeHostname} );
-  browser.tabs.reload();
-  window.close();
+  buildRemoveSitePanel(activeHostname);
 };
 
-const addSiteToContainer = async () => {
-  const activeHostname = await getActiveHostname();
+const addSiteToContainer = async (activeHostname) => {
+  if (!activeHostname) { throw new Error("Missing site name. Cannot add site."); }
   const fbcStorage = await browser.storage.local.get();
   fbcStorage.domainsAddedToFacebookContainer.push(activeHostname);
   await browser.storage.local.set({"domainsAddedToFacebookContainer": fbcStorage.domainsAddedToFacebookContainer});
   browser.tabs.reload();
   window.close();
 };
+
+const buildAddSitePanel = async (siteName) => {
+  if (!siteName) {
+    siteName = await getActiveHostname();
+  }
+
+  const panelId = "add-site";
+  const { page, fragment } = setUpPanel(panelId);
+
+  addHeaderWithBackArrow(fragment);
+
+  const contentWrapper = addDiv(fragment, "main-content-wrapper");
+  contentWrapper.classList.add("remove-site-panel");
+
+  addSubhead(contentWrapper, "add-site");
+  makeSiteList(contentWrapper, [siteName], true, false); // (..., sitesAllowed=true, addX=false )
+  addParagraph(contentWrapper, `${panelId}-p1`);
+  let blueRemoveButton = document.createElement("button");
+  blueRemoveButton.classList.add("uiMessage", "allow-btn");
+  blueRemoveButton.id = "btn-allow";
+  blueRemoveButton.addEventListener("click", async() => {
+    addSiteToContainer(siteName);
+  });
+
+  fragment.appendChild(blueRemoveButton);
+
+  getLocalizedStrings();
+
+  appendFragmentAndSetHeight(page, fragment);
+  addOnboardingListeners(siteName);
+};
+
 
 const buildRemoveSitePanel = (siteName) => {
   const panelId = "remove-site";


### PR DESCRIPTION
Fixes #585 

Added interstitial confirmation panel when adding site to the container.
Revised flow to include confirmation panel when removing site, if triggered from the main panel (and not the site list manager panel)

Reference: 
- [InVision Spec](https://mozilla.invisionapp.com/share/WNREP95GJ4V#/387099855_Sites_Allowed_Into_FBC)

## Testing Steps

### Adding Site: 
- Navigate to any non-FB container site in browser (Ex: firefox.com) 
- Open panel, click "Allow Site in Facebook Container"
- Expected: See "Allow" confirmation panel. 

![image](https://user-images.githubusercontent.com/2692333/74677910-2c0d7f80-517f-11ea-9fea-14eafc1725f2.png)


### Removing Site: 
- Navigate to any CUSTOM CONTAINED SITE inside the FB container site
- Open panel, click "Remove Site from Facebook Container" 
- Expected: See "Remove" confirmation panel (Exactly what is shown when going to "Sites Allowed in Facebook Container" > Clicking "X" on _Sites You've Allowed_ list) 

![image](https://user-images.githubusercontent.com/2692333/74677899-26179e80-517f-11ea-8d23-bec00d0e7914.png)


![image](https://user-images.githubusercontent.com/2692333/74677881-1e57fa00-517f-11ea-87a5-2e5265cf3354.png)

