### PR TITLE
Fixed #588 - Added logic to stop about: pages from being added to the container

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -432,7 +432,7 @@ async function updateBrowserActionIcon (tab) {
 
   const url = tab.url;
   const hasBeenAddedToFacebookContainer = await isAddedToFacebookContainer(url);
-  const aboutPageURLCheck = url.indexOf("about:");
+  const aboutPageURLCheck = url.startsWith("about:");
 
   if (isFacebookURL(url)) {
     // TODO: change panel logic from browser.storage to browser.runtime.onMessage

--- a/src/background.js
+++ b/src/background.js
@@ -441,7 +441,7 @@ async function updateBrowserActionIcon (tab) {
     browser.browserAction.setPopup({tabId: tab.id, popup: "./panel.html"});
   } else if (hasBeenAddedToFacebookContainer) {
     browser.storage.local.set({"CURRENT_PANEL": "in-fbc"});
-  } else if (aboutPageURLCheck > -1) {
+  } else if (aboutPageURLCheck) {
     // Sets CURRENT_PANEL if current URL is an internal about: page
     browser.storage.local.set({"CURRENT_PANEL": "about"});
   } else {

--- a/src/background.js
+++ b/src/background.js
@@ -432,8 +432,7 @@ async function updateBrowserActionIcon (tab) {
 
   const url = tab.url;
   const hasBeenAddedToFacebookContainer = await isAddedToFacebookContainer(url);
-
-
+  const aboutPageURLCheck = url.indexOf("about:");
 
   if (isFacebookURL(url)) {
     // TODO: change panel logic from browser.storage to browser.runtime.onMessage
@@ -442,6 +441,9 @@ async function updateBrowserActionIcon (tab) {
     browser.browserAction.setPopup({tabId: tab.id, popup: "./panel.html"});
   } else if (hasBeenAddedToFacebookContainer) {
     browser.storage.local.set({"CURRENT_PANEL": "in-fbc"});
+  } else if (aboutPageURLCheck > -1) {
+    // Sets CURRENT_PANEL if current URL is an internal about: page
+    browser.storage.local.set({"CURRENT_PANEL": "about"});
   } else {
     const tabState = tabStates[tab.id];
     const panelToShow = (tabState && tabState.trackersDetected) ? "trackers-detected" : "no-trackers";

--- a/src/panel.css
+++ b/src/panel.css
@@ -174,13 +174,16 @@ a:hover {
   background-image: url("/img/site-remove-icon.svg");
 }
 
-.highlight-on-hover.remove-site-from-container.disabled-button {
+.highlight-on-hover.remove-site-from-container.disabled-button, .highlight-on-hover.add-site-to-container.disabled-button {
   cursor: not-allowed;
   position: relative;
   z-index: 0;
 }
 
-.highlight-on-hover.remove-site-from-container.disabled-button::after, .highlight-on-hover.remove-site-from-container.disabled-button span {
+.highlight-on-hover.remove-site-from-container.disabled-button::after,
+.highlight-on-hover.remove-site-from-container.disabled-button span
+.highlight-on-hover.add-site-to-container.disabled-button::after,
+.highlight-on-hover.add-site-to-container.disabled-button span {
   opacity: 0.4;
 }
 

--- a/src/panel.js
+++ b/src/panel.js
@@ -178,8 +178,15 @@ const setCustomSiteButtonEvent = async (panelId) => {
   }
 
   const addSiteToContainerLink = document.querySelector(".add-site-to-container");
-  addSiteToContainerLink.addEventListener("click", async () => addSiteToContainer());
 
+  if (panelId === "about") {
+    // If on internal About: page, set button to disabled.
+    addSiteToContainerLink.classList.add("disabled-button");
+    return;
+  }
+
+  // Active site is eligable to be added to the container
+  addSiteToContainerLink.addEventListener("click", async () => addSiteToContainer());
 };
 
 // adds bottom navigation buttons to onboarding panels

--- a/src/panel.js
+++ b/src/panel.js
@@ -46,6 +46,7 @@ const setClassAndAppend = (wrapper, el) => {
 
 // add "uiMessage" class to element and appends.
 const addSubhead = (wrapper, panelId) => {
+  if (panelId === "about") { panelId = "no-trackers"; }
   const elemId = `${panelId}-subhead`;
   const el = document.createElement("h2");
   el["id"] = elemId;
@@ -352,7 +353,13 @@ const buildPanel = async(panelId) => {
     contentWrapper.appendChild(el);
   }
 
-  addParagraph(contentWrapper, `${panelId}-p1`);
+  // Because strings are named based on CURRENT_PANEL/panelID, this adds the
+  // same paragraph No Trackers Detected pages get for About: pages.
+  if (panelId === "about") {
+    addParagraph(contentWrapper, "no-trackers-p1");
+  } else {
+    addParagraph(contentWrapper, `${panelId}-p1`);
+  }
 
   if (panelId === "on-facebook") {
     addParagraph(contentWrapper, `${panelId}-p2`);


### PR DESCRIPTION
## Testing steps

- Navigate to any about: page (ex: `about:about`)
- Open panel, try to click on "Allow Site in Facebook Container"
- **Expected**: Button is grayed out, clicking does nothing

![image](https://user-images.githubusercontent.com/2692333/74686247-8960fb00-5196-11ea-8df4-95084b75a887.png)
