### PR TITLE
Fixed #608 - Added removal confirmation 

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -181,7 +181,10 @@ const setCustomSiteButtonEvent = async (panelId) => {
   if (shouldShowRemoveSiteButton) {
     const removeSiteFromContainerLink = document.querySelector(".remove-site-from-container");
     removeSiteFromContainerLink.addEventListener(
-      "click", async () => removeSiteFromContainer()
+      "click", async () => {
+        const activeRootDomain = await getActiveRootDomainFromBackground();
+        buildRemoveSitePanel(activeRootDomain);
+      }
     );
     return;
   }
@@ -553,17 +556,6 @@ const buildAllowedSitesPanel = async(panelId) => {
 
   addOnboardingListeners(panelId);
   getLocalizedStrings();
-};
-
-const removeSiteFromContainer = async () => {
-  const activeRootDomain = await getActiveRootDomainFromBackground();
-
-  await browser.runtime.sendMessage({
-    message: "remove-domain-from-list",
-    removeDomain: activeRootDomain
-  });
-  browser.tabs.reload();
-  window.close();
 };
 
 const addSiteToContainer = async () => {


### PR DESCRIPTION
- Fixed #608 

Added interstitial when removing sites from the first page of the doorhanger. Revised flow to include confirmation panel when removing site, if triggered from the main panel (and not the site list manager panel)

Reference: 
- [InVision Spec](https://mozilla.invisionapp.com/share/WNREP95GJ4V#/387099855_Sites_Allowed_Into_FBC)

## Testing Steps

### Removing Site: 
- Navigate to any CUSTOM CONTAINED SITE inside the FB container site
- Open panel, click "Remove Site from Facebook Container" 
- Expected: See "Remove" confirmation panel (Exactly what is shown when going to "Sites Allowed in Facebook Container" > Clicking "X" on _Sites You've Allowed_ list) 

![image](https://user-images.githubusercontent.com/2692333/74677899-26179e80-517f-11ea-8d23-bec00d0e7914.png)


![image](https://user-images.githubusercontent.com/2692333/74677881-1e57fa00-517f-11ea-87a5-2e5265cf3354.png)

