### PR TITLE
Added Giphy

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,9 @@ const FACEBOOK_DOMAINS = [
   "workplace.com", "www.workplace.com", "work.facebook.com",
 
   "onavo.com",
-  "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com"
+  "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com",
+
+  "giphy.com", "developers.giphy.com"
 ];
 
 const MAC_ADDON_ID = "@testpilot-containers";


### PR DESCRIPTION
Facebook recently bought Giphy. This PR adds `giphy.com` and `developers.giphy.com` to the list of domains to run inside the Facebook container.

Fixes #643