### PR TITLE
Allow external scripts to be loaded if  frame ancestor is valid Facebook domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Facebook Container isolates your Facebook activity from the rest of your web activity in order to prevent Facebook from tracking you outside of the Facebook website via third party cookies. ",
   "main": "background.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -523,14 +523,23 @@ async function blockFacebookSubResources (requestDetails) {
   }
 
   const urlIsFacebook = isFacebookURL(requestDetails.url);
-  const originUrlIsFacebook = isFacebookURL(requestDetails.originUrl);
-  const frameAncestorUrlIsFacebook = getFrameAncestorsURLAndCheckIfFacebook(requestDetails.frameAncestors);
-
+  // If this request isn't going to Facebook, let's return {} ASAP
   if (!urlIsFacebook) {
     return {};
   }
 
-  if (originUrlIsFacebook || frameAncestorUrlIsFacebook) {
+  const originUrlIsFacebook = isFacebookURL(requestDetails.originUrl);
+
+  if (originUrlIsFacebook) {
+    const message = {msg: "facebook-domain"};
+    // Send the message to the content_script
+    browser.tabs.sendMessage(requestDetails.tabId, message);
+    return {};
+  }
+
+  const frameAncestorUrlIsFacebook = getFrameAncestorsURLAndCheckIfFacebook(requestDetails.frameAncestors);
+
+  if (frameAncestorUrlIsFacebook) {
     const message = {msg: "facebook-domain"};
     // Send the message to the content_script
     browser.tabs.sendMessage(requestDetails.tabId, message);

--- a/src/background.js
+++ b/src/background.js
@@ -289,6 +289,16 @@ function getRootDomain(url) {
 
 }
 
+function getFrameAncestorsURLAndCheckIfFacebook(frameAncestorsArray) {
+  if (!frameAncestorsArray || frameAncestorsArray.length === 0) {
+    // No frame ancestor return false
+    return false;
+  }
+
+  const frameAncestorsURL = frameAncestorsArray[0].url;
+  return isFacebookURL(frameAncestorsURL);
+}
+
 function isFacebookURL (url) {
   const parsedUrl = new URL(url);
   for (let facebookHostRE of facebookHostREs) {
@@ -507,12 +517,13 @@ async function blockFacebookSubResources (requestDetails) {
 
   const urlIsFacebook = isFacebookURL(requestDetails.url);
   const originUrlIsFacebook = isFacebookURL(requestDetails.originUrl);
+  const frameAncestorUrlIsFacebook = getFrameAncestorsURLAndCheckIfFacebook(requestDetails.frameAncestors);
 
   if (!urlIsFacebook) {
     return {};
   }
 
-  if (originUrlIsFacebook) {
+  if (originUrlIsFacebook || frameAncestorUrlIsFacebook) {
     const message = {msg: "facebook-domain"};
     // Send the message to the content_script
     browser.tabs.sendMessage(requestDetails.tabId, message);

--- a/src/background.js
+++ b/src/background.js
@@ -295,7 +295,14 @@ function getFrameAncestorsURLAndCheckIfFacebook(frameAncestorsArray) {
     return false;
   }
 
+  const appsFacebookURL = "https://apps.facebook.com";
   const frameAncestorsURL = frameAncestorsArray[0].url;
+
+  if (!frameAncestorsURL.startsWith(appsFacebookURL)) {
+    // Only allow frame ancestors that originate from apps.facebook.com
+    return false;
+  }
+
   return isFacebookURL(frameAncestorsURL);
 }
 

--- a/src/background.js
+++ b/src/background.js
@@ -289,7 +289,7 @@ function getRootDomain(url) {
 
 }
 
-function getFrameAncestorsURLAndCheckIfFacebook(frameAncestorsArray) {
+function topFrameUrlIsFacebookApps(frameAncestorsArray) {
   if (!frameAncestorsArray || frameAncestorsArray.length === 0) {
     // No frame ancestor return false
     return false;
@@ -303,7 +303,7 @@ function getFrameAncestorsURLAndCheckIfFacebook(frameAncestorsArray) {
     return false;
   }
 
-  return isFacebookURL(frameAncestorsURL);
+  return frameAncestorsURL;
 }
 
 function isFacebookURL (url) {
@@ -537,9 +537,9 @@ async function blockFacebookSubResources (requestDetails) {
     return {};
   }
 
-  const frameAncestorUrlIsFacebook = getFrameAncestorsURLAndCheckIfFacebook(requestDetails.frameAncestors);
+  const frameAncestorUrlIsFacebookApps = topFrameUrlIsFacebookApps(requestDetails.frameAncestors);
 
-  if (frameAncestorUrlIsFacebook) {
+  if (frameAncestorUrlIsFacebookApps) {
     const message = {msg: "facebook-domain"};
     // Send the message to the content_script
     browser.tabs.sendMessage(requestDetails.tabId, message);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Facebook Container",
-    "version": "2.1.1",
+    "version": "2.2.0",
 
     "incognito": "not_allowed",
 


### PR DESCRIPTION
## Summary 

This PR addresses issues with allow-listed domains requesting/loading resources on Facebook. This happens on https://apps.facebook.com where Facebook has authorized the game developers to load resources from their websites into Facebook.  

- Fixes #663 


## Testing

- Log into Facebook
- Go to https://apps.facebook.com/wordswithfriends/
- Expected results: It loads without error.
  - Specifically, the FB.js SDK (`https://connect.facebook.net/en_US/sdk.js`) should load