### PR TITLE
Fixed #669 – Check target opacity for visibility

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -153,8 +153,6 @@ function shouldBadgeBeSmall(ratioCheck, itemHeight) {
 }
 
 function addFacebookBadge (target, badgeClassUId, socialAction) {
-  // Detect if target is visible
-
   const htmlBadgeDiv = createBadgeFragment(socialAction);
 
   const htmlBadgeFragmentPromptButtonCancel = htmlBadgeDiv.querySelector(".fbc-badge-prompt-btn-cancel");
@@ -318,12 +316,23 @@ function getOffsetsAndApplyClass(elemRect, bodyRect, target, htmlBadgeDiv) {
   }
 }
 
+function isOpaque(target){
+  // Check if any parents have 0 opacity
+  let current = target;
+  while(current != null){
+    if( window.getComputedStyle(current, false).getPropertyValue("opacity") === "0" ) return false;
+    current = current.parentElement;
+  }
+  return true;
+}
+
 function isVisible(target) {
   const currentComputedStyle = window.getComputedStyle(target, false);
   const styleTransform = ( currentComputedStyle.getPropertyValue("transform") === "matrix(1, 0, 0, 0, 0, 0)" );
   const styleHidden = ( currentComputedStyle.getPropertyValue("visibility") === "hidden" );
   const styleDisplayNone = ( currentComputedStyle.getPropertyValue("display") === "none" );
-  if (styleTransform || styleHidden || styleDisplayNone) return false;
+  const styleOpacityNone = !isOpaque(target);
+  if (styleTransform || styleHidden || styleDisplayNone || styleOpacityNone ) return false;
   return true;
 }
 
@@ -420,6 +429,7 @@ function positionFacebookBadge (target, badgeClassUId, targetWidth, smallSwitch)
     target = document.querySelector("." + target);
   }
 
+  // Detect if target is visible
   if (!checkVisibilityAndApplyClass(target, htmlBadgeDiv)) {
     return;
   }


### PR DESCRIPTION
The issue in #669 with ArtStation is that the login modal is hidden by setting the opacity to 0, which the extension doesn't check for. I fixed this by adding a check to determine if the target or its parent(s) have 0 opacity. I also moved a comment to its relevant section.