### PR TITLE
Add facebookrecruiting.com domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Facebook Container isolates your Facebook activity from the rest of your web activity in order to prevent Facebook from tracking you outside of the Facebook website via third party cookies. ",
   "main": "background.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,7 @@ const FACEBOOK_CONTAINER_DETAILS = {
 const FACEBOOK_DOMAINS = [
   "facebook.com", "www.facebook.com", "facebook.net", "fb.com",
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
-  "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
+  "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net", "facebookrecruiting.com",
 
   "instagram.com",
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Facebook Container",
-    "version": "2.2.0",
+    "version": "2.2.1",
 
     "incognito": "not_allowed",
 


### PR DESCRIPTION
## Summary

This PR adds https://facebookrecruiting.com/ as a default Facebook domain. 

## Testing

- Go to https://facebookrecruiting.com/
- Expected: Opens up inside the Facebook container 