### PR TITLE
add panel for email fields to link to relay

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -257,8 +257,8 @@
      "message": "This site can share your email address with Facebook, which allows Facebook to track you. Use a service like Firefox Relay to hide your real email address.",
      "description": ""
    },
-   "btn-relay-learn": {
-     "message": "Learn More",
+   "btn-relay-dismiss": {
+     "message": "Dismiss",
      "description": ""
    },
    "btn-relay-try": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -244,5 +244,25 @@
    "inPageUI-tooltip-button-share-passive": {
      "message": "If you click this button, Facebook will be able to track your visit to this site.",
      "description": ""
+   },
+   "inPageUI-tooltip-button-email": {
+     "message": "If you use your real email address here, Facebook may be able to track you. Click to learn more.",
+     "description": ""
+   },
+   "inPageUI-tooltip-email-prompt-p1": {
+     "message": "Allow Facebook to track you here?",
+     "description": ""
+   },
+   "inPageUI-tooltip-email-prompt-p2": {
+     "message": "This site can share your email address with Facebook, which allows Facebook to track you. Use a service like Firefox Relay to hide your real email address.",
+     "description": ""
+   },
+   "btn-relay-learn": {
+     "message": "Learn More",
+     "description": ""
+   },
+   "btn-relay-try": {
+     "message": "Try Firefox Relay",
+     "description": ""
    }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -24,6 +24,10 @@ const FACEBOOK_DOMAINS = [
   "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com"
 ];
 
+const DEFAULT_SETTINGS = {
+  hideRelayEmailBadges: false,
+};
+
 const MAC_ADDON_ID = "@testpilot-containers";
 const RELAY_ADDON_ID = "private-relay@firefox.com";
 
@@ -37,6 +41,30 @@ const tabsWaitingToLoad = {};
 const tabStates = {};
 
 const facebookHostREs = [];
+
+async function updateSettings(data){
+  await browser.storage.local.set({
+    "settings": data
+  });
+}
+
+async function checkSettings(setting){
+  let fbcStorage = await browser.storage.local.get();
+
+  if (setting) {
+    return fbcStorage.settings[setting];
+  }
+
+  if (fbcStorage.settings) {
+    return fbcStorage.settings;
+  }
+
+  await browser.storage.local.set({
+    "settings": DEFAULT_SETTINGS
+  });
+
+}
+
 
 async function isRelayAddonEnabled () {
   try {
@@ -645,6 +673,11 @@ function setupWindowsAndTabsListeners() {
       return getRootDomain(request.url);
     case "get-relay-enabled":
       return relayAddonEnabled;
+    case "update-settings":
+      updateSettings(request.settings);
+      break;
+    case "check-settings":
+      return checkSettings();
     default:
       throw new Error("Unexpected message!");
     }

--- a/src/content_script.css
+++ b/src/content_script.css
@@ -250,6 +250,11 @@
 	line-height: 20px;
 }
 
+.fbc-badge-prompt-dontShowAgain-checkbox {
+	display: flex;
+	align-items: center;
+}
+
 .fbc-badge-prompt-buttons {
 	position: absolute;
 	bottom: 0.15px;

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -352,7 +352,7 @@ function addFacebookBadge (target, badgeClassUId, socialAction) {
 
     // Add to Container "Allow"
     htmlEmailBadgeFragmentPromptButtonTry.addEventListener("click", () => {
-      window.open("https://relay.firefox.com");
+      window.open("https://relay.firefox.com/?utm_source=firefox&utm_medium=addon&utm_campaign=Facebook%20Container&utm_content=Try%20Firefox%20Relay");
     });
 
     // Dismiss email/relay prompt

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -288,12 +288,12 @@ function addFacebookBadge (target, badgeClassUId, socialAction) {
     });
 
     // Add to Container "Allow"
-    htmlEmailBadgeFragmentPromptButtonTry.addEventListener("click", (e) => {
+    htmlEmailBadgeFragmentPromptButtonTry.addEventListener("click", () => {
       window.open("https://relay.firefox.com");
     });
 
     // Open learn more link
-    htmlEmailBadgeFragmentPromptButtonLearn.addEventListener("click", (e) => {
+    htmlEmailBadgeFragmentPromptButtonLearn.addEventListener("click", () => {
       window.open("https://support.mozilla.org/en-US/kb/facebook-container-prevent-facebook-tracking#w_how-does-email-tracking-work");
     });
   } else if (socialAction === "share-passive") {

--- a/src/panel.js
+++ b/src/panel.js
@@ -1,5 +1,3 @@
-/* global browser */
-
 // TODO
 // Send message to background.js the first time that onboarding "Done" button is clicked and onboarding has been completed.
 

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,14 +1,14 @@
 module.exports = {
-    "parserOptions": {
-        "ecmaVersion": 8
-    },
-    "env": {
-        "node": true,
-        "mocha": true
-    },
-    "globals": {
-        "expect": false,
-        "loadWebExtension": false,
-        "sinon": false
-    }
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
+  "env": {
+    "node": true,
+    "mocha": true
+  },
+  "globals": {
+    "expect": false,
+    "loadWebExtension": false,
+    "sinon": false
+  }
 };

--- a/test/functional/.eslintrc.js
+++ b/test/functional/.eslintrc.js
@@ -5,4 +5,4 @@ module.exports = {
     By: false,
     internalUUID: false
   }
-}
+};


### PR DESCRIPTION
@maxxcrawford just an idea right now ... couple things I noticed that I might need help with ...

* The panel pops up when you select any email input field - should we make it only pop up when someone clicks the fence badge?
* The fence badge in the email input field conflicts with the relay badge in the email input field if both are installed. Any way to detect the relay badge and remove the fence in that case?
* Probably more I haven't thought of?