### PR TITLE
Settings Page/Options

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -244,5 +244,9 @@
    "inPageUI-tooltip-button-share-passive": {
      "message": "If you click this button, Facebook will be able to track your visit to this site.",
      "description": ""
+   },
+   "fbcSettingsTitle": {
+     "message": "Preferences",
+     "description": ""
    }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -48,11 +48,17 @@ async function buildBlockList() {
 }
 
 async function updateSettings(data){
+  let fbcStorage = await browser.storage.local.get();
+
   await browser.storage.local.set({
     "settings": data
   });
-  clearFacebookCookies();
-  await generateFacebookHostREs();
+
+  // Recache Blocked Domains List
+  if (data.blockInstagram != fbcStorage.settings.blockInstagram) {
+    clearFacebookCookies();
+    await generateFacebookHostREs();
+  }
 }
 
 const MAC_ADDON_ID = "@testpilot-containers";

--- a/src/background.js
+++ b/src/background.js
@@ -61,6 +61,12 @@ async function updateSettings(data){
   }
 }
 
+async function checkSettings(setting){
+  console.log( DEFAULT_SETTINGS[setting] );
+  return "foo";
+  // return DEFAULT_SETTINGS[setting];
+}
+
 const MAC_ADDON_ID = "@testpilot-containers";
 
 let macAddonEnabled = false;
@@ -667,6 +673,8 @@ function setupWindowsAndTabsListeners() {
     case "update-settings":
       updateSettings(request.settings);
       break;
+    case "check-settings":
+      return checkSettings(request.settings);
     default:
       throw new Error("Unexpected message!");
     }

--- a/src/background.js
+++ b/src/background.js
@@ -61,10 +61,9 @@ async function updateSettings(data){
   }
 }
 
-async function checkSettings(setting){
-  console.log( DEFAULT_SETTINGS[setting] );
-  return "foo";
-  // return DEFAULT_SETTINGS[setting];
+async function checkSettings(){
+  let fbcStorage = await browser.storage.local.get();
+  return fbcStorage.settings;
 }
 
 const MAC_ADDON_ID = "@testpilot-containers";
@@ -674,7 +673,7 @@ function setupWindowsAndTabsListeners() {
       updateSettings(request.settings);
       break;
     case "check-settings":
-      return checkSettings(request.settings);
+      return checkSettings();
     default:
       throw new Error("Unexpected message!");
     }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -654,3 +654,13 @@ function contentScriptSetTimeout() {
   }
   setTimeout(contentScriptSetTimeout, contentScriptDelay);
 }
+
+(function(){
+
+  const backgroundResp = await browser.runtime.sendMessage({
+    message: "check-settings",
+    settings: "badgeContent"
+  });
+
+
+})();

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -491,6 +491,7 @@ function patternDetection(selectionArray, socialActionIntent){
       const itemUIDClassTarget = "js-" + itemUIDClassName;
       const socialAction = socialActionIntent;
       facebookDetectedElementsArr.push(itemUIDClassName);
+      // TODO: Add logic to gate drawing badges based on local storage (settings.badgeContent)
       addFacebookBadge(item, itemUIDClassTarget, socialAction);
       item.classList.add("fbc-has-badge");
       item.classList.add(itemUIDClassName);

--- a/src/img/default-info.svg
+++ b/src/img/default-info.svg
@@ -1,0 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="context-fill" fill-opacity="context-fill-opacity">
+  <path fill-rule="evenodd" d="M8 1a7 7 0 1 1-7 7 7 7 0 0 1 7-7zm0 3a1 1 0 1 1-1 1 1 1 0 0 1 1-1zm0 3a1 1 0 0 1 1 1v3a1 1 0 0 1-2 0V8a1 1 0 0 1 1-1z"></path>
+</svg>

--- a/src/img/preferences.svg
+++ b/src/img/preferences.svg
@@ -1,0 +1,4 @@
+<!-- Thi¬¬s Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="context-fill" d="M15 7h-2.1a4.967 4.967 0 0 0-.732-1.753l1.49-1.49a1 1 0 0 0-1.414-1.414l-1.49 1.49A4.968 4.968 0 0 0 9 3.1V1a1 1 0 0 0-2 0v2.1a4.968 4.968 0 0 0-1.753.732l-1.49-1.49a1 1 0 0 0-1.414 1.415l1.49 1.49A4.967 4.967 0 0 0 3.1 7H1a1 1 0 0 0 0 2h2.1a4.968 4.968 0 0 0 .737 1.763c-.014.013-.032.017-.045.03l-1.45 1.45a1 1 0 1 0 1.414 1.414l1.45-1.45c.013-.013.018-.031.03-.045A4.968 4.968 0 0 0 7 12.9V15a1 1 0 0 0 2 0v-2.1a4.968 4.968 0 0 0 1.753-.732l1.49 1.49a1 1 0 0 0 1.414-1.414l-1.49-1.49A4.967 4.967 0 0 0 12.9 9H15a1 1 0 0 0 0-2zM5 8a3 3 0 1 1 3 3 3 3 0 0 1-3-3z"></path></svg>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -67,5 +67,10 @@
             "js": ["content_script.js"],
             "css": ["content_script.css"]
         }
-    ]
+    ],
+
+    "options_ui": {
+      "page": "options.html",
+      "browser_style": true
+    }
 }

--- a/src/options.css
+++ b/src/options.css
@@ -1,0 +1,81 @@
+body {
+  --white: #F2F2F3;
+  --black: #202023;
+  --borders: 1px solid #ededf0;
+  font-family: "SF Pro Text", 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
+  font-size: 16px;
+  min-height: 300px;
+}
+
+header {
+  border-bottom: var(--borders);
+  padding: 0.5rem 0;
+}
+
+header h1 {
+  font-size: 1.25rem;
+  text-align: center;
+}
+
+main {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 0;
+}
+
+section {
+  border-bottom: var(--borders);
+  padding: 0.5rem 0;
+}
+
+main h2 {
+  font-size: 1rem;
+}
+
+.tooltip {
+	display: none;
+	padding: 5px 10px 10px;
+	width: 250px;
+	max-width: 250px;
+	background: var(--white);
+	z-index: 9999;
+	position: absolute;
+  left: 50%;
+  top: 50%;
+	/* left: calc( 100% + 0.5em);
+	top: 50%; */
+	color: var(--black);
+	font-size: 1rem;
+	line-height: 17px;
+	border: 1px solid #BEBEBF;
+	box-shadow: 0 2px 4px 0 rgba(0,0,0,0.1);
+	font-family: "SF Pro Text", 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif !important;
+}
+
+.tooltip-parent:hover .tooltip {
+  display: block;
+}
+
+.tooltip-parent {
+  position: relative;
+  display: inline-block;
+}
+
+.settings-list > ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.setting-item {
+  position: relative;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    --borders: 1px solid #4C4C4E;
+
+    background: var(--black);
+    color: var(--white);
+  }
+}

--- a/src/options.css
+++ b/src/options.css
@@ -56,6 +56,11 @@ main h2 {
   display: block;
 }
 
+.tooltip-parent svg {
+  position: relative;
+  display: inline-block;
+}
+
 .tooltip-parent {
   position: relative;
   display: inline-block;
@@ -71,11 +76,29 @@ main h2 {
   position: relative;
 }
 
+.inline-fbc-icon {
+  display: inline-block;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, .15);
+	background-position: center center;
+	background-size: 6px auto, 100%;
+	background-image: url(/img/fence-large.svg), linear-gradient(-45deg, #6200A4, #D70022);
+	background-repeat: no-repeat;
+	border-radius: 100%;
+	width: 12px;
+	height: 12px;
+	padding: 0;
+	border: 1px solid white;
+	cursor: pointer;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     --borders: 1px solid #4C4C4E;
 
     background: var(--black);
     color: var(--white);
+  }
+  .tooltip-parent .tooltip-icon {
+    fill: var(--white);
   }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="options.css">
+  </head>
+	<body>
+		<header>
+      <h1 data-i18n="facebookContainer" class="i18n-string"></h1>
+    </header>
+    <main>
+      <section class="settings-list">
+        <h2>Blocking</h2>
+        <ul>
+          <li>
+            <div class="setting-item">
+              <input id="instagram" type="checkbox" name="instagram" value="">
+              <label for="instagram">Disable Instagram
+              </label>
+
+              <div class="tooltip-parent">
+                <img class="" src="/img/default-info.svg" alt="">
+                <div class="tooltip">
+                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                </div>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div class="setting-item">
+              <input id="instagram" type="checkbox" name="instagram" value="">
+              <label for="instagram">Disable Badges</label>
+              <div class="tooltip-parent">
+                <img class="" src="/img/default-info.svg" alt="">
+                <div class="tooltip">
+                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                </div>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <script src="options.js"></script>
+	</body>
+</html>

--- a/src/options.html
+++ b/src/options.html
@@ -15,8 +15,8 @@
         <ul>
           <li>
             <div class="setting-item">
-              <input id="instagram" type="checkbox" name="instagram" value="">
-              <label for="instagram">Disable Instagram
+              <input class="settings-checkbox" id="blockInstagram" type="checkbox" name="instagram" value="">
+              <label for="blockInstagram">Block Instagram
               </label>
 
               <div class="tooltip-parent">
@@ -29,8 +29,8 @@
           </li>
           <li>
             <div class="setting-item">
-              <input id="instagram" type="checkbox" name="instagram" value="">
-              <label for="instagram">Disable Badges</label>
+              <input class="settings-checkbox" id="badgeContent" type="checkbox" name="badgeContent" value="">
+              <label for="badgeContent">Add Badges</label>
               <div class="tooltip-parent">
                 <img class="" src="/img/default-info.svg" alt="">
                 <div class="tooltip">

--- a/src/options.html
+++ b/src/options.html
@@ -11,7 +11,7 @@
     </header>
     <main>
       <section class="settings-list">
-        <h2>Blocking</h2>
+        <h2 class="i18n-string" data-i18n="fbcSettingsTitle"></h2>
         <ul>
           <li>
             <div class="setting-item">
@@ -20,7 +20,9 @@
               </label>
 
               <div class="tooltip-parent">
-                <img class="" src="/img/default-info.svg" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="context-fill" fill-opacity="context-fill-opacity">
+                  <path class="tooltip-icon" fill-rule="evenodd" d="M8 1a7 7 0 1 1-7 7 7 7 0 0 1 7-7zm0 3a1 1 0 1 1-1 1 1 1 0 0 1 1-1zm0 3a1 1 0 0 1 1 1v3a1 1 0 0 1-2 0V8a1 1 0 0 1 1-1z"></path>
+                </svg>
                 <div class="tooltip">
                   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
                 </div>
@@ -30,9 +32,11 @@
           <li>
             <div class="setting-item">
               <input class="settings-checkbox" id="badgeContent" type="checkbox" name="badgeContent" value="">
-              <label for="badgeContent">Add Badges</label>
+              <label for="badgeContent"><img class="inline-fbc-icon" src="fbc-icon.svg" alt=""> Add FBC Badge to Share/Login elements across non-Facebook sites </label>
               <div class="tooltip-parent">
-                <img class="" src="/img/default-info.svg" alt="">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="context-fill" fill-opacity="context-fill-opacity">
+                  <path class="tooltip-icon" fill-rule="evenodd" d="M8 1a7 7 0 1 1-7 7 7 7 0 0 1 7-7zm0 3a1 1 0 1 1-1 1 1 1 0 0 1 1-1zm0 3a1 1 0 0 1 1 1v3a1 1 0 0 1-2 0V8a1 1 0 0 1 1-1z"></path>
+                </svg>
                 <div class="tooltip">
                   Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
                 </div>

--- a/src/options.html
+++ b/src/options.html
@@ -44,6 +44,7 @@
             </div>
           </li>
         </ul>
+        <button type="button" id="resetSettingsButton" name="button">Reset settings to default</button>
       </section>
     </main>
 

--- a/src/options.js
+++ b/src/options.js
@@ -9,6 +9,20 @@ function getLocalizedStrings() {
   }
 }
 
+async function resetSettingsToDefault() {
+  const checkboxes = document.querySelectorAll(".settings-checkbox");
+  checkboxes.forEach((item) => {
+    item.checked = true;
+  });
+
+  const settings = buildSettingsObject();
+  await browser.runtime.sendMessage({
+    message: "update-settings",
+    settings
+  });
+
+}
+
 function buildSettingsObject() {
   let data = {};
   const checkboxes = document.querySelectorAll(".settings-checkbox");
@@ -37,6 +51,9 @@ async function updateSettings() {
   });
 
   await settingsCheckboxListener();
+
+  const resetSettingsButton = document.getElementById("resetSettingsButton");
+  resetSettingsButton.addEventListener("click", () => resetSettingsToDefault(), false);
 }
 
 function settingsCheckboxListener(){

--- a/src/options.js
+++ b/src/options.js
@@ -9,6 +9,51 @@ function getLocalizedStrings() {
   }
 }
 
+function buildSettingsObject() {
+  let data = {};
+  const checkboxes = document.querySelectorAll(".settings-checkbox");
+
+  checkboxes.forEach((item) => {
+    let settingName = item.id;
+    Object.defineProperty(data, settingName, {
+      value: item.checked,
+      writable: true,
+      configurable: true,
+      enumerable: true
+    });
+  });
+
+  return data;
+}
+
+async function updateSettings() {
+  let localStorage = await browser.storage.local.get();
+
+  const checkboxes = document.querySelectorAll(".settings-checkbox");
+
+  checkboxes.forEach((item) => {
+    let settingName = item.id;
+    item.checked = localStorage.settings[settingName];
+  });
+
+  await settingsCheckboxListener();
+}
+
+function settingsCheckboxListener(){
+  const checkboxes = document.querySelectorAll(".settings-checkbox");
+
+  checkboxes.forEach((item) => {
+    item.addEventListener("change", async () => {
+      const settings = buildSettingsObject();
+      await browser.runtime.sendMessage({
+        message: "update-settings",
+        settings
+      });
+    });
+  });
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
   getLocalizedStrings();
+  await updateSettings();
 });

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,14 @@
+"use strict";
+
+function getLocalizedStrings() {
+  const strings = document.querySelectorAll(".i18n-string");
+  for (let string of strings) {
+    const stringID = string.dataset.i18n;
+    const localizedTextString = browser.i18n.getMessage(stringID);
+    string.textContent = localizedTextString;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
+  getLocalizedStrings();
+});

--- a/src/panel.css
+++ b/src/panel.css
@@ -68,6 +68,19 @@ h1 { /* "Facebook Container" headline for all panels */
   cursor: pointer;
 }
 
+.btn-settings.gear {
+  z-index: 2;
+  position: absolute;
+  border: 0;
+  right: 15px;
+  top: 15px;
+  width: 1.2rem;
+  height: 1.2rem;
+  background-color: rgba(255, 255, 255, 1);
+  background-image: url("/img/preferences.svg?v=3");
+  cursor: pointer;
+}
+
 h2 { /* panel sub-head for all panels */
   display: flex;
   align-items: center;
@@ -371,7 +384,8 @@ a:hover {
 .highlight-on-hover::after,
 .Facebook-text::after,
 .trackers-detected-subhead::before,
-.btn-return.arrow-left {
+.btn-return.arrow-left,
+.btn-settings.gear {
   content: "";
   background-repeat: no-repeat;
   background-size: contain;

--- a/src/panel.js
+++ b/src/panel.js
@@ -358,7 +358,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 // Build non-onboarding panel
 const buildPanel = async(panelId) => {
   const { page, fragment } = setUpPanel(panelId);
-  addHeader(fragment);
+  addHeaderWithGearIcon(fragment);
 
   const contentWrapper = addDiv(fragment, "main-content-wrapper");
   addSubhead(contentWrapper, panelId);
@@ -401,8 +401,16 @@ const buildPanel = async(panelId) => {
 
   const onboardingLinks = document.querySelectorAll(".open-onboarding");
   const allowedSitesLink = document.querySelector(".open-allowed-sites");
+  const settingsLink = document.querySelector(".btn-settings");
 
   allowedSitesLink.addEventListener("click", () => buildAllowedSitesPanel("sites-allowed"));
+  settingsLink.addEventListener("click", () => {
+    browser.tabs.create({
+      url: "/options.html",
+      active: true
+    });
+    window.close();
+  });
 
   await setCustomSiteButtonEvent(panelId);
 
@@ -473,6 +481,13 @@ const addHeaderWithBackArrow = (fragment) => {
   return fragment;
 };
 
+const addHeaderWithGearIcon = (fragment) => {
+  let el = addHeader(fragment);
+  el = document.createElement("button");
+  el.classList.add("btn-settings", "gear");
+  fragment.appendChild(el);
+  return fragment;
+};
 
 const defaultAllowedSites = [
   "instagram.com",


### PR DESCRIPTION
## Features

This PR adds a preferences panel (accessible from both the add-on panel and the `about:addons` page). Beyond adding this space for future options/prefs, I added two options to start: 

1. Allow Instagram data. This would allow IG embedded posts to load. 
2. Turn off badging on non-Facebook pages. This would not put purple circles on login buttons, etc. 

## Testing 

TBD

## Screenshots

Gear Icon to open prefernces page: 
<img width="401" alt="image" src="https://user-images.githubusercontent.com/2692333/106054678-fe7cc600-60b1-11eb-84c2-7a861c5dcb78.png">

`about:addons` preferences pane (WIP) 
<img width="724" alt="image" src="https://user-images.githubusercontent.com/2692333/106054703-063c6a80-60b2-11eb-94ac-674c3bea7f70.png">



 
