### PR TITLE
Add oversightboard.com to the list of Facebook domains.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,7 +21,9 @@ const FACEBOOK_DOMAINS = [
   "workplace.com", "www.workplace.com", "work.facebook.com",
 
   "onavo.com",
-  "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com"
+  "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com",
+
+  "oversightboard.com", "www.oversightboard.com"
 ];
 
 const MAC_ADDON_ID = "@testpilot-containers";


### PR DESCRIPTION
The blog on https://oversightboard.com/ is broken for users with Facebook Container installed. All their CSS and JS is hosted on `fbcdn.net`, which gets blocked by the container.

Since oversightboard.com is run by Facebook, I think the easiest fix for that is to add the domain to the list of Facebook domains, so that any access to that site happens within the Facebook Container, where everything works fine. :)