### PR TITLE
Add bulletin.com to the list of Facebook domains

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -23,7 +23,9 @@ const FACEBOOK_DOMAINS = [
   "onavo.com",
   "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com",
 
-  "oversightboard.com", "www.oversightboard.com"
+  "oversightboard.com", "www.oversightboard.com",
+  
+  "bulletin.com"
 ];
 
 const MAC_ADDON_ID = "@testpilot-containers";


### PR DESCRIPTION
`bulletin.com` is a new Facebook site. Currently does not appear to be usable with Facebook Container on since it tries to GET a large number of resources from `fbcdn.com`.