### PR TITLE
Fix #783 - Email prompt badging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Facebook Container isolates your Facebook activity from the rest of your web activity in order to prevent Facebook from tracking you outside of the Facebook website via third party cookies. ",
   "main": "background.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -647,6 +647,15 @@ function setupWindowsAndTabsListeners() {
   browser.windows.onFocusChanged.addListener(windowFocusChangedListener);
 }
 
+async function checkIfTrackersAreDetected(sender) {
+  const activeTab = await getActiveTab();
+  const tabState = tabStates[activeTab.id];
+  const trackersDetected = (tabState && tabState.trackersDetected);
+  const onActiveTab = (activeTab.id === sender.tab.id);
+  // Check if trackers were blocked,scoped to the active tab.
+  return (onActiveTab && trackersDetected);  
+}
+
 (async function init () {
   await setupMACAddonListeners();
   macAddonEnabled = await isMACAddonEnabled();
@@ -686,6 +695,8 @@ function setupWindowsAndTabsListeners() {
       break;
     case "check-settings":
       return checkSettings();
+    case "are-trackers-detected":
+      return await checkIfTrackersAreDetected(sender);
     default:
       throw new Error("Unexpected message!");
     }

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -646,9 +646,13 @@ async function detectFacebookOnPage () {
   patternDetection(SHARE_PATTERN_DETECTION_SELECTORS, "share");
   patternDetection(LOGIN_PATTERN_DETECTION_SELECTORS, "login");
   const relayAddonEnabled = await getRelayAddonEnabledFromBackground();
+  
+  // Check if any FB trackers were blocked, scoped to only the active tab
+  const trackersDetectedOnCurrentPage = await checkIfTrackersAreDetectedOnCurrentPage();
+
   // Check if user dismissed the Relay prompt
   const relayAddonPromptDismissed = await getLocalStorageSettingFromBackground("hideRelayEmailBadges");
-  if (!relayAddonEnabled && !relayAddonPromptDismissed.hideRelayEmailBadges) {
+  if (!relayAddonEnabled && !relayAddonPromptDismissed.hideRelayEmailBadges && trackersDetectedOnCurrentPage) {
     patternDetection(EMAIL_PATTERN_DETECTION_SELECTORS, "email");
     updateSettings();
   }
@@ -760,6 +764,13 @@ async function getRelayAddonEnabledFromBackground() {
     message: "get-relay-enabled"
   });
   return relayAddonEnabled;
+}
+
+async function checkIfTrackersAreDetectedOnCurrentPage() {
+  const trackersDetected = await browser.runtime.sendMessage({
+    message: "are-trackers-detected"
+  });
+  return trackersDetected;
 }
 
 async function getRootDomainFromBackground(url) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Facebook Container",
-    "version": "2.3.0",
+    "version": "2.3.1",
 
     "incognito": "not_allowed",
 


### PR DESCRIPTION
This PR scopes the email input prompt to only sites that have had Facebook resources blocked on them. 

## Testing: 

**Test case: No email prompt expected**

- Navigate to https://bugzilla.mozilla.org
- Click "Login" button
- Focus on "Email" field (if not done automatically) 
- **Expected:** There should be no FBC badge on the input field. 

**Test case: Email prompt visible**

- Navigate to https://www.airbnb.com/login 
- **Expected:** The "Continue with Facebook" button should have a FBC badge
- Click "Continue with Email" button
- **Expected:** The email input field should have a FBC badge