### PR TITLE
tighten up CSS selectors on is-hidden class

### DIFF
--- a/src/content_script.css
+++ b/src/content_script.css
@@ -349,6 +349,6 @@ body {
 	bottom: 25%;
 }
 
-.is-hidden {
+#fbc-email.is-hidden, #fbc-login.is-hidden {
     display: none;
 }


### PR DESCRIPTION
Addresses #886 which is caused by too general application of styling on the `is-hidden` class