### PR TITLE
Add Meta owned URLS to FBC contained URLs list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contain-facebook",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "description": "Facebook Container isolates your Facebook activity from the rest of your web activity in order to prevent Facebook from tracking you outside of the Facebook website via third party cookies. ",
   "main": "background.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -13,6 +13,8 @@ const FACEBOOK_DOMAINS = [
   
   "facebookrecruiting.com", "facebookblueprint.com",
 
+  "fburl.com", "internalfb.com",
+
   "instagram.com",
   "cdninstagram.com", "instagramstatic-a.akamaihd.net", "instagramstatic-a.akamaihd.net.edgesuite.net",
 

--- a/src/background.js
+++ b/src/background.js
@@ -27,7 +27,7 @@ const FACEBOOK_DOMAINS = [
   "onavo.com",
   "oculus.com", "oculusvr.com", "oculusbrand.com", "oculusforbusiness.com",
 
-  "mapwith.ai", "wit.ai",
+  "mapwith.ai", "wit.ai", "mapillary.com",
 
   "oversightboard.com", "www.oversightboard.com",
   

--- a/src/background.js
+++ b/src/background.js
@@ -7,7 +7,7 @@ const FACEBOOK_CONTAINER_DETAILS = {
 };
 
 const FACEBOOK_DOMAINS = [
-  "facebook.com", "www.facebook.com", "facebook.net", "fb.com",
+  "facebook.com", "www.facebook.com", "facebook.net", "fb.com", "fb.me",
   "fbcdn.net", "fbcdn.com", "fbsbx.com", "tfbnw.net",
   "facebook-web-clients.appspot.com", "fbcdn-profile-a.akamaihd.net", "fbsbx.com.online-metrix.net", "connect.facebook.net.edgekey.net",
   

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Facebook Container",
-    "version": "2.3.9",
+    "version": "2.3.10",
 
     "incognito": "not_allowed",
 


### PR DESCRIPTION
While reviewing https://github.com/mozilla/contain-facebook/issues/699, a user mentioned FB URLs that were missing from the container list. Added! 

To test: 
- Install FBC
- Navigate to:
    - https://www.internalfb.com/login
    - https://fburl.com/debugjs (will redirect to the above URL)
    - https://mapillary.com (#843)
    - https://fb.me (#847) 
- Expected: URLs re-open inside the Facebook Container