### PR TITLE
Fix 'runtime message removeDomain > should have removed the domain' test

### DIFF
--- a/src/panel.js
+++ b/src/panel.js
@@ -141,7 +141,7 @@ const isSiteInContainer = async(panelId) => {
 
   const activeRootDomain = await getActiveRootDomainFromBackground();
 
-  if (addedSitesList.includes(activeRootDomain)) {
+  if (addedSitesList && addedSitesList.includes(activeRootDomain)) {
     return true;
   }
 };
@@ -345,7 +345,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   const storage = await browser.storage.local.get();
   const currentPanel = storage.CURRENT_PANEL;
 
-  const onboarding = (currentPanel.includes("onboarding"));
+  const onboarding = (currentPanel && currentPanel.includes("onboarding"));
   if (!onboarding) {
     return buildPanel(currentPanel);
   }

--- a/test/features/add-domain-to-fbc.test.js
+++ b/test/features/add-domain-to-fbc.test.js
@@ -31,6 +31,8 @@ describe("Add domain to Facebook Container", () => {
           removeDomain: "example.com"
         });
 
+        await sleep();
+
         const [promise] = await background.browser.runtime.onMessage.addListener.yield({message: "what-sites-are-added"});
         const sites = await promise;
         expect(sites.includes("example.com")).to.be.false;
@@ -39,3 +41,7 @@ describe("Add domain to Facebook Container", () => {
   });
 
 });
+
+async function sleep(ms = 100) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Still not 100% sure why it needs a pause between the two commands:
- `await background.browser.runtime.onMessage.addListener.yield({message: "remove-domain-from-list", ...})`
- `await background.browser.runtime.onMessage.addListener.yield({message: "what-sites-are-added"})`

&hellip; but here we are. Seems to work since I get:

>   34 passing (5s)
>  1 passing (3s)

<details>
<summary><kbd>npm test</kbd></summary>

```sh
npm test

> contain-facebook@2.3.9 test
> eslint src test && npm run coverage && npm run test-functional


> contain-facebook@2.3.9 coverage
> nyc --reporter=html --reporter=text mocha --reporter=progress test/setup.js test/features/*.test.js --timeout 60000


  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  34 passing (5s)

---------------|---------|----------|---------|---------|----------------------------------------------------------------
File           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
---------------|---------|----------|---------|---------|----------------------------------------------------------------
All files      |   61.06 |    50.74 |   67.42 |   58.73 |
 background.js |   83.72 |    70.32 |      90 |   83.44 | ...449,480-482,532,543,551,603-606,626,655-660,675-676,694-705
 panel.js      |   37.28 |    23.68 |   38.77 |   37.71 | ...391,414-462,467-471,488-520,526-559,563-568,572-599,604-633
 psl.min.js    |   71.42 |    45.08 |   75.75 |     100 | 2
---------------|---------|----------|---------|---------|----------------------------------------------------------------

> contain-facebook@2.3.9 test-functional
> mocha --reporter=progress test/functional/setup.js test/functional/*.test.js --timeout 60000


Building web extension from /private/tmp/contain-facebook/build
Destination exists, overwriting: /private/tmp/contain-facebook/.web-ext-artifacts/facebook_container-2.3.9.zip
Your web extension is ready: /private/tmp/contain-facebook/.web-ext-artifacts/facebook_container-2.3.9.zip
  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  1 passing (3s)
```
</details>

---

The second commit just fixes the DDoS flood of "TypeError: Cannot read properties of undefined (reading 'includes')" errors which seemed to be coming from 2 places in src/panel.js. So I guess it's possible for `addedSitesList` and `onboarding` to be null/undefined in some cases. 🤷 