### PR TITLE
Add meta.ai in the FACEBOOK_DOMAINS list

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -33,7 +33,7 @@ const FACEBOOK_DOMAINS = [
   
   "bulletin.com", "facebookbrand.com",
 
-  "metacareers.com", "meta.com",  "metaque.st",
+  "metacareers.com", "meta.com",  "metaque.st", "meta.ai",
 
   "novi.com",
 


### PR DESCRIPTION
This adds `meta.ai` (the website of Meta AI) in the FACEBOOK_DOMAINS list found in the `src/background.js` file.

This solve Issue #991.