### PR TITLE
Add whatsapp.com in the FACEBOOK_DOMAINS list

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -37,7 +37,9 @@ const FACEBOOK_DOMAINS = [
 
   "novi.com",
 
-  "threads.net", "threads.com"
+  "threads.net", "threads.com",
+
+  "whatsapp.com"
 ];
 
 const DEFAULT_SETTINGS = {


### PR DESCRIPTION
This adds `whatsapp.com/` (the website of WhatsApp messaging app) in the `FACEBOOK_DOMAINS` list found in the `src/background.js` file.