### PR TITLE
Add meta.ai to FB domains

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -37,7 +37,9 @@ const FACEBOOK_DOMAINS = [
 
   "novi.com",
 
-  "threads.net", "threads.com"
+  "threads.net", "threads.com",
+
+  "meta.ai"
 ];
 
 const DEFAULT_SETTINGS = {


### PR DESCRIPTION
Adding Meta.ai to the list of FB owned domains.

Currently meta.ai fails to load, as fbcdn related requests are blocked on non-fb containers. 

<img width="1706" height="593" alt="image" src="https://github.com/user-attachments/assets/57498259-26ec-4424-9a27-3f38c3d8f236" />

---------------

## Test
`npm test` doesn't pass, which is also the case on `main`

```
 1) Add domain to Facebook Container
       runtime message add-domain-to-list
         runtime message removeDomain
           should have removed the domain:

      AssertionError: expected true to be false
      + expected - actual

      -true
      +false

      at Context.<anonymous> (test/features/add-domain-to-fbc.test.js:36:52)
```