### PR TITLE
fix(content): only remove .fbc-wrapper when one already existed

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -327,8 +327,9 @@ function openInputPrompt(socialAction, fencePos, target, fbcIframeHeight) {
       }
     });
     postMessageListeners(iframeSrcVal, target);
+  } else {
+    hasFbcWrapper.remove();
   }
-  hasFbcWrapper.remove();
 }
 
 function postMessageListeners(iframeSrcVal, target){


### PR DESCRIPTION
## Summary

Closes #1008.

`openInputPrompt` queries for an existing `.fbc-wrapper` and, when one is missing, injects a fresh wrapper into the page. The trailing call

```js
hasFbcWrapper.remove();
```

was placed *outside* the if/else block, so it ran unconditionally, including on the first badge click of a page when no wrapper existed and one was just created. The result was

```
TypeError: hasFbcWrapper is null
    at openInputPrompt (src/content_script.js:331)
```

and the prompt failed to open until a second click rebuilt the missing branch.

## Fix

Move `hasFbcWrapper.remove()` into an `else` branch so it only runs when an existing wrapper is being torn down to make room for the new injection.

```js
if (!hasFbcWrapper) {
    document.body.appendChild(injectIframeOntoPage(...));
    ...
} else {
    hasFbcWrapper.remove();
}
```

## Test plan

- [x] `node -c src/content_script.js`, passes
- [ ] Manual: load the extension, click any Facebook login badge as the very first interaction on a fresh page, confirm the in-page prompt opens without a console TypeError